### PR TITLE
refactor(constants): use JournalCategory enum keys for reviewQuestions

### DIFF
--- a/lib/core/constants/review_questions.dart
+++ b/lib/core/constants/review_questions.dart
@@ -1,23 +1,25 @@
+import 'package:dytty/core/constants/categories.dart';
+
 /// Review questions for each journal category.
 /// Used by the AI review call to guide reflection.
-const Map<String, List<String>> reviewQuestions = {
-  'positive': [
+const Map<JournalCategory, List<String>> reviewQuestions = {
+  JournalCategory.positive: [
     'Is the feeling lasting?',
     'Did you take action on this feeling?',
   ],
-  'negative': [
+  JournalCategory.negative: [
     'Is the feeling lasting — same intensity?',
     'Did you take action toward resolving or cherishing it?',
   ],
-  'gratitude': [
+  JournalCategory.gratitude: [
     'Grateful for good things, and that bad things weren\'t the worst?',
     'Is your ability to be grateful improving?',
   ],
-  'beauty': [
+  JournalCategory.beauty: [
     'Appreciating good things daily?',
     'Appreciating beyond visual — taste, sound, other senses?',
   ],
-  'identity': [
+  JournalCategory.identity: [
     'Overall identity for the week based on entries?',
     'Which to adopt more, which to forgo?',
   ],

--- a/lib/features/category_detail/category_detail_screen.dart
+++ b/lib/features/category_detail/category_detail_screen.dart
@@ -134,7 +134,7 @@ class _CategoryDetailViewState extends State<_CategoryDetailView> {
       (c) => c.name == widget.categoryId,
       orElse: () => JournalCategory.positive,
     );
-    final questions = reviewQuestions[widget.categoryId] ?? [];
+    final questions = reviewQuestions[category] ?? [];
     final entries = _allRecentEntries();
     final prompt = buildReviewPrompt(category.displayName, questions, entries);
 
@@ -262,7 +262,7 @@ class _CategoryDetailViewState extends State<_CategoryDetailView> {
         (c) => c.name == widget.categoryId,
         orElse: () => JournalCategory.positive,
       );
-      final questions = reviewQuestions[widget.categoryId] ?? [];
+      final questions = reviewQuestions[category] ?? [];
 
       try {
         final response = await llmService.generateResponse(

--- a/test/core/constants/review_questions_test.dart
+++ b/test/core/constants/review_questions_test.dart
@@ -1,19 +1,11 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:dytty/core/constants/categories.dart';
 import 'package:dytty/core/constants/review_questions.dart';
 
 void main() {
   group('reviewQuestions', () {
     test('contains all 5 journal categories', () {
-      expect(
-        reviewQuestions.keys,
-        containsAll([
-          'positive',
-          'negative',
-          'gratitude',
-          'beauty',
-          'identity',
-        ]),
-      );
+      expect(reviewQuestions.keys, containsAll(JournalCategory.values));
       expect(reviewQuestions.length, 5);
     });
 


### PR DESCRIPTION
## Summary
- Changed `reviewQuestions` map from `Map<String, List<String>>` to `Map<JournalCategory, List<String>>`
- Updated consumers in `category_detail_screen.dart` to use the already-resolved `category` enum variable
- Updated existing tests to check enum keys

## Test plan
- [x] Existing review_questions_test updated and passing
- [x] `flutter analyze` clean
- [x] `flutter test` all 630 tests green

Fixes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)