### PR TITLE
fix(notifications): set device timezone for correct reminder scheduling

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,14 +1,16 @@
 # Dytty Progress
 
 ## Current Status
-**PR #104 code review refactors complete. All 7 issues (#105-#114) merged.**
+**Notifications fixed and tested. Code review refactors + release infra merged.**
 
 **Latest on main:**
-- All PR #104 code review refactors landed (7 PRs merged)
-- `formatRelativeTime` shared utility (#105), `recentDaysCount` constant (#106), enum keys for `reviewQuestions` (#107), CallBadgeIcon a11y fix (#112), silent catch → error states (#114), ReviewCallController extraction (#111), CallSession utility (#113)
-- Version: 0.1.7+9
+- All PR #104 code review refactors landed (#105-#114, PRs #124-#131, #133)
+- Release infra overhaul (#121): shared debug keystore, distribute.sh with tags + GitHub Releases
+- Dynamic version display (#27), Firestore index (#119), timestamp warnings (#108)
+- Version on main: 0.1.7+9
 
-**Open PRs:** None
+**Open PRs:**
+- #128 — Notification fixes (timezone, auth, permissions, channels, receivers) — tested working on device
 
 **Test status:** 671 Flutter + 32 Playwright + 9 Maestro = 712 tests. Coverage: 82.3% (CI gate: 50%)
 
@@ -29,13 +31,13 @@ Update `min_coverage` in `.github/workflows/ci.yml` each week.
 | Milestone | Status |
 |-----------|--------|
 | M0–M4 | Done |
-| M5: Weekly Review | In progress — #71 Category Detail Page (all 7 phases done, needs manual testing) |
+| M5: Weekly Review | In progress — #71 Category Detail Page landed, code review refactors merged |
 | M6: Categories + Polish | Data model done. UI settings page pending |
 | M7: Launch Prep | Not started |
 
 ## Blockers
 - Web build requires `--no-tree-shake-icons` due to dynamic IconData in CategoryConfig
-- #95: CI auto-distribution requires `FIREBASE_SERVICE_ACCOUNT_DYTTY_4B83D` secret
+- #130: google-services.json was committed to git history — assess key rotation before public release
 
 ## Up Next
 - **#86**: Journal entries lost on app restart (P0, offline persistence)
@@ -43,28 +45,35 @@ Update `min_coverage` in `.github/workflows/ci.yml` each week.
 - **#82**: Security audit — Firestore rules, API keys, audio encryption (P0)
 - **#79**: Data export + account deletion for GDPR (P0)
 - **#78**: iOS build for close-circle distribution (P0)
+- **#122**: Daily call AI conversation quality (P0 — repetition, no follow-ups, poor category handling)
+- **#123**: Transcript bubbles truncated (P1)
 - **#90**: Error state flash on call start (race condition)
-- **#95**: Enable CI auto-distribution (infra)
 - **#48**: Golden test CI failures (cross-platform fonts)
-- Coverage at 81.7% — ahead of ratchet schedule, bump CI gate
+- Coverage at ~82% — ahead of ratchet schedule, bump CI gate
 
 ---
 
 ## Log
 
 ### 2026-03-20 (session 28)
-- **PR #104 code review refactors — all 7 issues complete**
-  - PRs 1-4 implemented in parallel worktrees, PRs 5-7 sequential (overlapping files)
-  - Each PR: TDD (tests first), implement, analyze, test, push, code review, apply fixes, merge
-  - **#105** (PR #125): `formatRelativeTime` → shared utility with injectable `now` param for deterministic tests
-  - **#106** (PR #124): magic number 7 → `recentDaysCount` constant with clarifying comment
-  - **#107** (PR #127): `reviewQuestions` string keys → `JournalCategory` enum keys
-  - **#112** (PR #126): `_CallBadgeIcon` GestureDetector → IconButton (a11y + tooltip)
-  - **#114** (PR #129): silent catch blocks → emit error state + BlocListener SnackBars, optimistic revert on all 3 operations
-  - **#111** (PR #131): extracted `ReviewCallController` (ChangeNotifier) from `_CategoryDetailViewState` — screen 611→374 lines, factory injection for testability, `_disposed` guards on all async paths
-  - **#113** (PR #133): extracted `CallSession` utility — granular API (initPlayback, startRecording, stop, dispose), used by both ReviewCallController and VoiceCallScreen
-  - 703/703 tests passing (671 Flutter + 32 Playwright), 82.3% coverage
-  - Key decisions: injectable `now` for time utils, granular CallSession API (not monolithic `start()`) to accommodate Gemini connect interleaving, `onError` callback pattern for controller→screen error reporting
+- **Notification pipeline fixed end-to-end (#26, #132)** — 9 builds (0.1.8+11 through +19) to diagnose and fix the full 8-link Android notification chain:
+  - flutter_timezone 5.x returns `TimezoneInfo` not `String` (runtime crash)
+  - `requestPermission()` returns null when already granted — added `areNotificationsEnabled()` fallback
+  - `SCHEDULE_EXACT_ALARM` in manifest caused Android 14+ to reject alarms — removed
+  - `ScheduledNotificationReceiver` + `ScheduledNotificationBootReceiver` + `ActionBroadcastReceiver` missing from AndroidManifest
+  - Notification channels never created explicitly — Android 8+ silently drops without channels
+  - `multiDexEnabled` added for Android 14+ compatibility
+  - `google_sign_in` 7.x requires `initialize()` before `authenticate()` (auto-resolves serverClientId from google-services.json)
+- **Created `scripts/android-diag.sh`** — diagnostic script for the full notification pipeline
+- **PR #104 code review refactors — all 7 issues complete** (parallel agent)
+  - #105, #106, #107, #112, #114 (PRs #124-#129), #111 (PR #131), #113 (PR #133)
+  - Key decisions: injectable `now` for time utils, granular CallSession API, `onError` callback pattern
+  - 703 tests passing, 82.3% coverage
+- **PR #120 merged** — dynamic app version (#27), Firestore index (#119), timestamp warnings (#108)
+- **PR #121 merged** — release infra overhaul (shared debug keystore, distribute.sh with tags + GitHub Releases)
+- **Issues verified and closed**: #26, #29, #61, #115, #132
+- **Issues created**: #119, #122 (AI quality), #123 (transcript truncation), #130 (security), #132
+- **Lesson learned**: always diagnose the full chain before fixing symptoms — created `/debug-android` skill
 
 ### 2026-03-19 (session 27)
 - **#92 Dependency upgrade — PR #103 merged**

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -24,14 +24,12 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId = "com.dytty.dytty"
-        // You can update the following values to match your application needs.
-        // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
+        multiDexEnabled = true
     }
 
     signingConfigs {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
-    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <application
         android:label="dytty"
@@ -35,6 +34,23 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+
+        <!-- flutter_local_notifications: handles scheduled notification alarms -->
+        <receiver android:exported="false"
+            android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationReceiver" />
+        <!-- flutter_local_notifications: reschedules notifications after device reboot -->
+        <receiver android:exported="false"
+            android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED"/>
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED"/>
+                <action android:name="android.intent.action.QUICKBOOT_POWERON"/>
+                <action android:name="com.htc.intent.action.QUICKBOOT_POWERON"/>
+            </intent-filter>
+        </receiver>
+        <!-- flutter_local_notifications: handles notification action buttons -->
+        <receiver android:exported="false"
+            android:name="com.dexterous.flutterlocalnotifications.ActionBroadcastReceiver" />
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/lib/services/auth/auth_service.dart
+++ b/lib/services/auth/auth_service.dart
@@ -11,9 +11,8 @@ class AuthService {
     : _auth = auth ?? FirebaseAuth.instance,
       _googleSignIn = googleSignIn;
 
-  // Lazy — avoids eager clientId assertion crash on web when no meta tag is set.
-  // serverClientId is required for google_sign_in_android 6.2+ (Credential Manager)
-  // to obtain an idToken. Value is the Web client OAuth ID from google-services.json.
+  bool _initialized = false;
+
   GoogleSignIn get _google => _googleSignIn ??= GoogleSignIn.instance;
 
   Stream<User?> get authStateChanges => _auth.authStateChanges();
@@ -25,6 +24,12 @@ class AuthService {
       throw Exception('Google Sign-In is not supported on this platform');
     }
 
+    // google_sign_in 7.x requires initialize() before authenticate().
+    // On Android, it auto-resolves serverClientId from google-services.json.
+    if (!_initialized) {
+      await _google.initialize();
+      _initialized = true;
+    }
     final googleUser = await _google.authenticate();
 
     final idToken = googleUser.authentication.idToken;

--- a/lib/services/notification/notification_service.dart
+++ b/lib/services/notification/notification_service.dart
@@ -1,8 +1,12 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_timezone/flutter_timezone.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:timezone/data/latest_all.dart' as tz;
 import 'package:timezone/timezone.dart' as tz;
+
+/// Returns the device's IANA timezone name (e.g. "America/Toronto").
+typedef TimezoneResolver = Future<String> Function();
 
 class NotificationService {
   static const _channelId = 'dytty_daily_reminder';
@@ -31,10 +35,19 @@ class NotificationService {
   static String? pendingRoute;
 
   final FlutterLocalNotificationsPlugin _plugin;
+  final TimezoneResolver _timezoneResolver;
   late final SharedPreferences _prefs;
 
-  NotificationService({FlutterLocalNotificationsPlugin? plugin})
-    : _plugin = plugin ?? FlutterLocalNotificationsPlugin();
+  NotificationService({
+    FlutterLocalNotificationsPlugin? plugin,
+    TimezoneResolver? timezoneResolver,
+  }) : _plugin = plugin ?? FlutterLocalNotificationsPlugin(),
+       _timezoneResolver = timezoneResolver ?? _defaultTimezoneResolver;
+
+  static Future<String> _defaultTimezoneResolver() async {
+    final info = await FlutterTimezone.getLocalTimezone();
+    return info.identifier;
+  }
 
   /// Top-level callback for notification responses (required by flutter_local_notifications).
   @pragma('vm:entry-point')
@@ -54,6 +67,8 @@ class NotificationService {
 
   Future<void> init() async {
     tz.initializeTimeZones();
+    final timezoneName = await _timezoneResolver();
+    tz.setLocalLocation(tz.getLocation(timezoneName));
     _prefs = await SharedPreferences.getInstance();
 
     const androidSettings = AndroidInitializationSettings(
@@ -73,6 +88,33 @@ class NotificationService {
       settings: settings,
       onDidReceiveNotificationResponse: _onNotificationResponse,
     );
+
+    // Explicitly create notification channels on Android 8+.
+    // Channels must exist before scheduling or notifications are silently dropped.
+    if (!kIsWeb) {
+      final android = _plugin
+          .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin
+          >();
+      if (android != null) {
+        await android.createNotificationChannel(
+          const AndroidNotificationChannel(
+            _channelId,
+            _channelName,
+            description: _channelDesc,
+            importance: Importance.high,
+          ),
+        );
+        await android.createNotificationChannel(
+          const AndroidNotificationChannel(
+            _callChannelId,
+            _callChannelName,
+            description: _callChannelDesc,
+            importance: Importance.high,
+          ),
+        );
+      }
+    }
 
     // Re-schedule if reminder was enabled from a previous session
     if (isReminderEnabled) {
@@ -230,6 +272,7 @@ class NotificationService {
   }
 
   /// Request notification permission (Android 13+, iOS).
+  /// Returns true if permission is granted (including already-granted).
   Future<bool> requestPermission() async {
     if (kIsWeb) return false;
 
@@ -238,7 +281,12 @@ class NotificationService {
           AndroidFlutterLocalNotificationsPlugin
         >();
     if (android != null) {
-      return await android.requestNotificationsPermission() ?? false;
+      // requestNotificationsPermission() can return null when permission
+      // is already granted on some devices. Check areNotificationsEnabled()
+      // as a fallback.
+      final result = await android.requestNotificationsPermission();
+      if (result == true) return true;
+      return await android.areNotificationsEnabled() ?? false;
     }
 
     final ios = _plugin

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,9 +6,13 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <flutter_timezone/flutter_timezone_plugin.h>
 #include <record_linux/record_linux_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) flutter_timezone_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterTimezonePlugin");
+  flutter_timezone_plugin_register_with_registrar(flutter_timezone_registrar);
   g_autoptr(FlPluginRegistrar) record_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "RecordLinuxPlugin");
   record_linux_plugin_register_with_registrar(record_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  flutter_timezone
   record_linux
 )
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -12,6 +12,7 @@ import firebase_core
 import firebase_storage
 import flutter_local_notifications
 import flutter_pcm_sound
+import flutter_timezone
 import google_sign_in_ios
 import package_info_plus
 import patrol
@@ -27,6 +28,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseStoragePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseStoragePlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterPcmSoundPlugin.register(with: registry.registrar(forPlugin: "FlutterPcmSoundPlugin"))
+  FlutterTimezonePlugin.register(with: registry.registrar(forPlugin: "FlutterTimezonePlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PatrolPlugin.register(with: registry.registrar(forPlugin: "PatrolPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -523,6 +523,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_timezone:
+    dependency: "direct main"
+    description:
+      name: flutter_timezone
+      sha256: e8d63f50f2806a3a71a08697286a0369e1d8f0902961327810459871c0bb01c2
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.2"
   flutter_web_plugins:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
   flutter_pcm_sound: ^3.3.3
   firebase_storage: ^13.1.0
   package_info_plus: ^9.0.0
+  flutter_timezone: ^5.0.2
 
 dev_dependencies:
   flutter_test:

--- a/scripts/android-diag.sh
+++ b/scripts/android-diag.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Android device diagnostic script for Dytty.
+# Checks the full notification pipeline and common failure points.
+#
+# Usage:
+#   bash scripts/android-diag.sh [device-serial]
+
+set -euo pipefail
+
+ADB="${ADB:-adb}"
+PKG="com.dytty.dytty"
+SERIAL="${1:-}"
+
+if [[ -n "$SERIAL" ]]; then
+  ADB="$ADB -s $SERIAL"
+fi
+
+echo "=== Dytty Android Diagnostics ==="
+echo ""
+
+# 1. Device connected?
+echo "--- Device ---"
+$ADB get-state 2>/dev/null || { echo "ERROR: No device connected"; exit 1; }
+echo "Connected: $($ADB shell getprop ro.product.model) (Android $($ADB shell getprop ro.build.version.release))"
+echo "Timezone: $($ADB shell getprop persist.sys.timezone)"
+echo "Time: $($ADB shell date)"
+echo ""
+
+# 2. App installed?
+echo "--- App ---"
+APP_INFO=$($ADB shell dumpsys package "$PKG" 2>/dev/null | grep "versionName\|versionCode\|targetSdkVersion" | head -3)
+if [[ -z "$APP_INFO" ]]; then
+  echo "ERROR: $PKG is NOT installed"
+  exit 1
+fi
+echo "$APP_INFO"
+echo ""
+
+# 3. Notification permission
+echo "--- Notification Permission ---"
+NOTIF_PERM=$($ADB shell dumpsys notification | grep "AppSettings: $PKG" || echo "NOT FOUND")
+echo "$NOTIF_PERM"
+echo ""
+
+# 4. Notification channels
+echo "--- Notification Channels ---"
+CHANNELS=$($ADB shell dumpsys notification | grep -A 20 "NotificationChannels" | grep -i "dytty" || echo "No channels found for $PKG")
+echo "$CHANNELS"
+echo ""
+
+# 5. Registered receivers
+echo "--- Manifest Receivers ---"
+RECEIVERS=$($ADB shell dumpsys package "$PKG" | grep -i "receiver\|ScheduledNotification\|BootReceiver" || echo "No receivers found")
+echo "$RECEIVERS"
+echo ""
+
+# 6. Scheduled alarms
+echo "--- Scheduled Alarms ---"
+ALARMS=$($ADB shell dumpsys alarm | grep -B 1 -A 6 "dytty" || echo "No alarms scheduled")
+echo "$ALARMS"
+echo ""
+
+# 7. Exact alarm permission
+echo "--- Exact Alarm Permission ---"
+EXACT=$($ADB shell cmd appops get "$PKG" SCHEDULE_EXACT_ALARM 2>/dev/null || echo "N/A")
+echo "$EXACT"
+echo ""
+
+# 8. Battery optimization
+echo "--- Battery Optimization ---"
+BATTERY=$($ADB shell dumpsys deviceidle whitelist | grep -i "dytty" || echo "NOT whitelisted (battery optimization active)")
+echo "$BATTERY"
+echo ""
+
+# 9. App standby bucket
+echo "--- App Standby Bucket ---"
+BUCKET=$($ADB shell am get-standby-bucket "$PKG" 2>/dev/null || echo "N/A")
+echo "Bucket: $BUCKET"
+echo ""
+
+# 10. Recent crashes
+echo "--- Recent Flutter Errors (last 50 lines) ---"
+$ADB logcat -d | grep -i "flutter.*Error\|flutter.*Exception\|dytty.*lost permission\|dytty.*crash" | tail -10 || echo "None found"
+echo ""
+
+echo "=== Diagnostics Complete ==="

--- a/test/features/settings/settings_cubit_test.dart
+++ b/test/features/settings/settings_cubit_test.dart
@@ -74,6 +74,12 @@ class FakeNotificationService extends NotificationService {
   Future<bool> requestPermission() async => true;
 }
 
+/// Simulates a device where notification permission is actually denied.
+class PermissionDeniedNotificationService extends FakeNotificationService {
+  @override
+  Future<bool> requestPermission() async => false;
+}
+
 void main() {
   late FakeFirebaseFirestore firestore;
   late JournalRepository repository;
@@ -343,6 +349,49 @@ void main() {
           NotificationService.defaultMinute,
         );
       },
+    );
+
+    blocTest<SettingsCubit, SettingsState>(
+      'toggle on then setReminderTime reschedules at new time',
+      build: () => SettingsCubit(
+        repository: repository,
+        notificationService: notificationService,
+      ),
+      seed: () => const SettingsState(loaded: true),
+      act: (cubit) async {
+        await cubit.toggleReminder();
+        await cubit.setReminderTime(const TimeOfDay(hour: 9, minute: 27));
+      },
+      expect: () => [
+        isA<SettingsState>().having(
+          (s) => s.reminderEnabled,
+          'reminderEnabled',
+          true,
+        ),
+        isA<SettingsState>().having(
+          (s) => s.reminderTime,
+          'reminderTime',
+          const TimeOfDay(hour: 9, minute: 27),
+        ),
+      ],
+      verify: (_) {
+        expect(notificationService.reminderHour, 9);
+        expect(notificationService.reminderMinute, 27);
+      },
+    );
+
+    blocTest<SettingsCubit, SettingsState>(
+      'toggleReminder does not enable when permission denied',
+      build: () {
+        notificationService = PermissionDeniedNotificationService();
+        return SettingsCubit(
+          repository: repository,
+          notificationService: notificationService,
+        );
+      },
+      seed: () => const SettingsState(loaded: true),
+      act: (cubit) => cubit.toggleReminder(),
+      expect: () => [], // no state change — permission denied
     );
   });
 

--- a/test/services/auth/auth_service_test.dart
+++ b/test/services/auth/auth_service_test.dart
@@ -34,6 +34,14 @@ void main() {
   setUp(() {
     mockAuth = MockFirebaseAuth();
     mockGoogleSignIn = MockGoogleSignIn();
+    when(
+      () => mockGoogleSignIn.initialize(
+        serverClientId: any(named: 'serverClientId'),
+        clientId: any(named: 'clientId'),
+        nonce: any(named: 'nonce'),
+        hostedDomain: any(named: 'hostedDomain'),
+      ),
+    ).thenAnswer((_) async {});
     service = AuthService(auth: mockAuth, googleSignIn: mockGoogleSignIn);
   });
 

--- a/test/services/notification/notification_service_test.dart
+++ b/test/services/notification/notification_service_test.dart
@@ -9,6 +9,9 @@ import 'package:dytty/services/notification/notification_service.dart';
 class MockFlutterLocalNotificationsPlugin extends Mock
     implements FlutterLocalNotificationsPlugin {}
 
+class MockAndroidFlutterLocalNotificationsPlugin extends Mock
+    implements AndroidFlutterLocalNotificationsPlugin {}
+
 void main() {
   late MockFlutterLocalNotificationsPlugin mockPlugin;
   late NotificationService service;
@@ -24,7 +27,10 @@ void main() {
 
   setUp(() {
     mockPlugin = MockFlutterLocalNotificationsPlugin();
-    service = NotificationService(plugin: mockPlugin);
+    service = NotificationService(
+      plugin: mockPlugin,
+      timezoneResolver: () async => 'America/Toronto',
+    );
 
     // Default stubs for plugin methods
     when(
@@ -100,6 +106,14 @@ void main() {
           ),
         ),
       ).called(1);
+    });
+
+    test('sets local timezone from device timezone', () async {
+      SharedPreferences.setMockInitialValues({});
+
+      await service.init();
+
+      expect(tz.local.name, 'America/Toronto');
     });
 
     test('re-schedules reminder if previously enabled', () async {
@@ -304,6 +318,35 @@ void main() {
       ).called(1);
     });
 
+    test('schedules in device local timezone, not UTC', () async {
+      SharedPreferences.setMockInitialValues({});
+      await service.init();
+
+      // Capture the scheduledDate passed to zonedSchedule
+      tz.TZDateTime? capturedDate;
+      when(
+        () => mockPlugin.zonedSchedule(
+          id: any(named: 'id'),
+          title: any(named: 'title'),
+          body: any(named: 'body'),
+          scheduledDate: any(named: 'scheduledDate'),
+          notificationDetails: any(named: 'notificationDetails'),
+          androidScheduleMode: any(named: 'androidScheduleMode'),
+          matchDateTimeComponents: any(named: 'matchDateTimeComponents'),
+          payload: any(named: 'payload'),
+        ),
+      ).thenAnswer((invocation) async {
+        capturedDate =
+            invocation.namedArguments[#scheduledDate] as tz.TZDateTime;
+      });
+
+      await service.scheduleDailyReminder(hour: 20, minute: 0);
+
+      expect(capturedDate, isNotNull);
+      expect(capturedDate!.location.name, 'America/Toronto');
+      expect(capturedDate!.hour, 20);
+    });
+
     test('persists enabled state and time to SharedPreferences', () async {
       SharedPreferences.setMockInitialValues({});
       await service.init();
@@ -445,6 +488,55 @@ void main() {
 
       expect(result, isFalse);
     });
+
+    test(
+      'returns true when requestNotificationsPermission returns null but notifications enabled',
+      () async {
+        SharedPreferences.setMockInitialValues({});
+        await service.init();
+
+        final mockAndroid = MockAndroidFlutterLocalNotificationsPlugin();
+        when(
+          () => mockPlugin
+              .resolvePlatformSpecificImplementation<
+                AndroidFlutterLocalNotificationsPlugin
+              >(),
+        ).thenReturn(mockAndroid);
+        when(
+          () => mockAndroid.requestNotificationsPermission(),
+        ).thenAnswer((_) async => null);
+        when(
+          () => mockAndroid.areNotificationsEnabled(),
+        ).thenAnswer((_) async => true);
+
+        final result = await service.requestPermission();
+
+        expect(result, isTrue);
+      },
+    );
+
+    test(
+      'returns true when requestNotificationsPermission returns true',
+      () async {
+        SharedPreferences.setMockInitialValues({});
+        await service.init();
+
+        final mockAndroid = MockAndroidFlutterLocalNotificationsPlugin();
+        when(
+          () => mockPlugin
+              .resolvePlatformSpecificImplementation<
+                AndroidFlutterLocalNotificationsPlugin
+              >(),
+        ).thenReturn(mockAndroid);
+        when(
+          () => mockAndroid.requestNotificationsPermission(),
+        ).thenAnswer((_) async => true);
+
+        final result = await service.requestPermission();
+
+        expect(result, isTrue);
+      },
+    );
   });
 
   group('pendingRoute (static)', () {

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -10,6 +10,7 @@
 #include <firebase_auth/firebase_auth_plugin_c_api.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
 #include <firebase_storage/firebase_storage_plugin_c_api.h>
+#include <flutter_timezone/flutter_timezone_plugin_c_api.h>
 #include <record_windows/record_windows_plugin_c_api.h>
 #include <speech_to_text_windows/speech_to_text_windows.h>
 
@@ -22,6 +23,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
   FirebaseStoragePluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FirebaseStoragePluginCApi"));
+  FlutterTimezonePluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FlutterTimezonePluginCApi"));
   RecordWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("RecordWindowsPluginCApi"));
   SpeechToTextWindowsRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -7,6 +7,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   firebase_auth
   firebase_core
   firebase_storage
+  flutter_timezone
   record_windows
   speech_to_text_windows
 )


### PR DESCRIPTION
## Summary
- Adds `flutter_timezone` to resolve the device's IANA timezone at init
- `NotificationService.init()` now calls `tz.setLocalLocation()` with the real device timezone instead of defaulting to UTC
- Bumps version to 0.1.8+10 for distribution testing

Without this fix, scheduled reminders fire at UTC time instead of local time (e.g. 8:15 PM UTC instead of 8:15 PM America/Toronto).

## Test plan
- [x] 636 Flutter tests pass (includes timezone-specific test verifying `America/Toronto`)
- [x] `flutter analyze` clean
- [ ] Set reminder for 2 minutes from now on Android device, verify it fires at correct local time
- [ ] Verify notification permission prompt appears on first enable

Fixes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)