### PR TITLE
fix: web Google Sign-In broken — use signInWithPopup (#143)

### DIFF
--- a/lib/services/auth/auth_service.dart
+++ b/lib/services/auth/auth_service.dart
@@ -1,6 +1,6 @@
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/foundation.dart' show kDebugMode, kIsWeb;
 import 'package:google_sign_in/google_sign_in.dart';
-import 'package:flutter/foundation.dart' show kDebugMode;
 import 'package:dytty/main.dart' show useEmulators;
 
 class AuthService {
@@ -20,6 +20,15 @@ class AuthService {
   User? get currentUser => _auth.currentUser;
 
   Future<UserCredential> signInWithGoogle() async {
+    // On web, google_sign_in's authenticate() is not supported (Credential
+    // Manager is Android/iOS only). Use Firebase Auth's signInWithPopup which
+    // handles the full OAuth flow via browser popup.
+    if (kIsWeb) {
+      final provider = GoogleAuthProvider();
+      return _auth.signInWithPopup(provider);
+    }
+
+    // On Android/iOS, use google_sign_in package with Credential Manager.
     if (!_google.supportsAuthenticate()) {
       throw Exception('Google Sign-In is not supported on this platform');
     }


### PR DESCRIPTION
## Summary
- Web app showed "Google Sign-In is not supported on this platform" because `google_sign_in` 7.x's `authenticate()` API is Android/iOS only
- Fix: on web, use Firebase Auth's `signInWithPopup(GoogleAuthProvider())` directly
- Root cause: web sign-in was never tested after the google_sign_in 6→7 upgrade — all web E2E used anonymous sign-in

## Test plan
- [x] 710 Flutter tests pass (0 regressions)
- [x] Manually verified: localhost:4201 → "Continue with Google" → popup opens → sign-in works
- [x] `flutter analyze` clean

Fixes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)