### PR TITLE
fix: add workflow chain enforcement and blocker protocol (#177)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,24 @@ The superpowers plugin provides structured workflows. Always check for applicabl
 
 Process skills (brainstorming, debugging) come first, then implementation skills (TDD, plans). Follow rigid skills exactly.
 
+### Post-Implementation Chain (mandatory, never skip)
+
+After `executing-plans` or `subagent-driven-development` completes ALL tasks:
+1. `verification-before-completion` — run tests, verify claims with evidence
+2. `finishing-a-development-branch` — handles PR creation (never create PR manually)
+3. `requesting-code-review` — auto-chains after PR, never ask "want me to review?"
+4. Update `kb/PROGRESS.md` — log entry with decisions/tradeoffs
+
+Each step invokes the next. Do not stop between steps or ask the user.
+
+### Blocker Protocol
+
+When any workflow step fails (e.g., can't push branch, CI blocks, permission denied):
+- **STOP.** Do not skip the step or make autonomous workarounds.
+- **Report** the exact error to the user.
+- **Ask** for direction before proceeding.
+- Never retarget PRs, skip dev/* branches, or bypass workflow steps without explicit user approval.
+
 ## Conventions
 - Files: snake_case (daily_journal_screen.dart)
 - Classes: PascalCase


### PR DESCRIPTION
## Summary
- Added **Post-Implementation Chain** section to CLAUDE.md: after `executing-plans` or `subagent-driven-development`, the agent must auto-chain through `verification-before-completion`, `finishing-a-development-branch`, `requesting-code-review`, and `kb/PROGRESS.md` update without stopping or asking.
- Added **Blocker Protocol** section: when any workflow step fails, stop and report instead of making autonomous workarounds (e.g., retargeting PRs, skipping dev/* branches).

## Context
During #175, the agent skipped 3 mandatory post-implementation skills after a blocker (dev/* ruleset) caused it to pivot. The ruleset is now fixed; this PR documents the enforcement rules to prevent recurrence.

Fixes #177

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Confirm the two new subsections appear under "Superpowers Plugin"
- [ ] No code changes — `flutter analyze` clean (only pre-existing info-level issues)

Generated with [Claude Code](https://claude.com/claude-code)