### PR TITLE
fix(voice-call): update deprecated Gemini Live model name (#157)

### DIFF
--- a/lib/services/voice_call/gemini_live_service.dart
+++ b/lib/services/voice_call/gemini_live_service.dart
@@ -26,6 +26,9 @@ class Transcript {
 ///
 /// Manages session lifecycle, audio I/O, tool calling, and latency tracking.
 class GeminiLiveService {
+  /// Preview model — subject to deprecation/rename by Google.
+  /// If daily call breaks with WebSocket 1008 "model not found", check:
+  /// https://firebase.google.com/docs/ai-logic/models
   static const _model = 'gemini-2.5-flash-native-audio-preview-12-2025';
 
   /// Tag used for structured log lines, filterable via `adb logcat`.

--- a/lib/services/voice_call/gemini_live_service.dart
+++ b/lib/services/voice_call/gemini_live_service.dart
@@ -26,7 +26,7 @@ class Transcript {
 ///
 /// Manages session lifecycle, audio I/O, tool calling, and latency tracking.
 class GeminiLiveService {
-  static const _model = 'gemini-2.5-flash-preview-native-audio';
+  static const _model = 'gemini-2.5-flash-native-audio-preview-12-2025';
 
   /// Tag used for structured log lines, filterable via `adb logcat`.
   static const _logTag = '[DYTTY]';


### PR DESCRIPTION
## Summary
- Update model from `gemini-2.5-flash-preview-native-audio` (deprecated) to `gemini-2.5-flash-native-audio-preview-12-2025`
- One-line fix in `gemini_live_service.dart`

## Root Cause
The model was removed/renamed. WebSocket connected briefly then closed with code 1008: "model not found for API version v1main". The original hypothesis (142-line prompt too long) was wrong — the model was never reached.

## Diagnosis Method
Used the acoustic test harness (orchestrate.py + Maestro) to automate the daily call E2E test on a physical Pixel 9a. Logcat revealed the exact WebSocket error. After fixing the model name, logcat shows `[DYTTY] User said: Hey` — the model is processing audio correctly.

## Test plan
- [x] 47 Dart voice call tests pass
- [x] flutter analyze clean
- [x] Device test: call connects, user audio recognized, no WebSocket errors
- [ ] Gate 1 CI passes

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)