### PR TITLE
fix(bloc): state-refresh cluster — markers survive streak failure, today-sourced dashboard, error UX (#189)

### DIFF
--- a/.maestro/state/data-loads-after-restart.yaml
+++ b/.maestro/state/data-loads-after-restart.yaml
@@ -1,0 +1,46 @@
+appId: com.dytty.dytty
+name: "State: data loads on app restart without interaction"
+tags:
+  - state
+  - regression
+---
+# Regression test for #189/#49: calendar markers, category icons and the
+# progress card must reflect today's entries right after a cold start,
+# with zero user interaction.
+
+- runFlow: "../helpers/login.yaml"
+
+# Clean slate for this flow
+- assertVisible: "Progress 0 of 5"
+
+# Ensure today has one entry
+- tapOn: "Today button"
+- waitForAnimationToEnd
+- tapOn: "Add Positive Things entry"
+- waitForAnimationToEnd
+- tapOn: "What good things happened today.*"
+- eraseText
+- inputText: "Restart persistence entry"
+- tapOn: "Save"
+- waitForAnimationToEnd:
+    timeout: 5000
+- assertVisible: ".*Restart persistence entry.*"
+
+- back
+- waitForAnimationToEnd:
+    timeout: 5000
+- assertVisible: "Progress 1 of 5.*"
+
+# Kill the app and relaunch WITHOUT clearing state — auth session and
+# Firestore cache persist, mirroring a real user reopening the app.
+- stopApp
+- launchApp
+- waitForAnimationToEnd:
+    timeout: 15000
+- waitForAnimationToEnd:
+    timeout: 10000
+
+# Dashboard must reflect today's entry with no interaction (#189/#49)
+- assertVisible: "Progress 1 of 5.*"
+
+- takeScreenshot: ".maestro/screenshots/latest/state/bug189-progress-after-restart"

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -9,13 +9,6 @@
       ]
     },
     {
-      "collectionGroup": "dailyEntries",
-      "queryScope": "COLLECTION",
-      "fields": [
-        { "fieldPath": "__name__", "order": "DESCENDING" }
-      ]
-    },
-    {
       "collectionGroup": "reviewSummaries",
       "queryScope": "COLLECTION",
       "fields": [

--- a/firestore.rules
+++ b/firestore.rules
@@ -20,6 +20,11 @@ service cloud.firestore {
       match /reviewSummaries/{summaryId} {
         allow read, write: if request.auth != null && request.auth.uid == userId;
       }
+
+      // Category configuration subcollection
+      match /categories/{categoryId} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
     }
 
     // Deny all other access

--- a/lib/data/repositories/journal_repository.dart
+++ b/lib/data/repositories/journal_repository.dart
@@ -241,9 +241,10 @@ class JournalRepository {
   /// Computes streak data by walking dailyEntries backward from today.
   /// Returns {currentStreak, longestStreak, lastJournalDate}.
   Future<StreakData> getStreakData() async {
-    final snapshot = await _dailyEntriesCollection
-        .orderBy(FieldPath.documentId, descending: true)
-        .get();
+    // No server-side orderBy: doc IDs are collected into a Set and sorted
+    // client-side below. orderBy(__name__ DESC) required a composite index
+    // that was never deployed, failing every cold start (#170, #189).
+    final snapshot = await _dailyEntriesCollection.get();
 
     final dates = snapshot.docs.map((doc) => doc.id).toSet();
     if (dates.isEmpty) {

--- a/lib/features/daily_journal/bloc/journal_bloc.dart
+++ b/lib/features/daily_journal/bloc/journal_bloc.dart
@@ -113,6 +113,11 @@ class JournalState extends Equatable {
   final DateTime selectedDate;
   final List<CategoryEntry> entries;
   final Map<String, Map<String, int>> monthCategoryMarkers;
+
+  /// Today's per-category entry counts, independent of which month
+  /// [monthCategoryMarkers] currently holds. Survives month navigation so
+  /// the dashboard (nudge + progress card) always reflects today (#154).
+  final Map<String, int> todayCategoryCounts;
   final int currentStreak;
   final String? lastJournalDate;
   final String? error;
@@ -124,22 +129,27 @@ class JournalState extends Equatable {
     DateTime? selectedDate,
     this.entries = const [],
     this.monthCategoryMarkers = const {},
+    Map<String, int>? todayCategoryCounts,
     this.currentStreak = 0,
     this.lastJournalDate,
     this.error,
-  }) : selectedDate = selectedDate ?? DateTime.now();
+  }) : selectedDate = selectedDate ?? DateTime.now(),
+       // Derive from markers when not explicitly provided, so directly
+       // constructed states (tests, initial load) stay consistent.
+       todayCategoryCounts =
+           todayCategoryCounts ??
+           Map<String, int>.from(
+             monthCategoryMarkers[_dateFormat.format(DateTime.now())] ??
+                 const {},
+           );
 
   String get selectedDateString => _dateFormat.format(selectedDate);
 
   /// Backward-compatible derived getter — dates that have any entries.
   Set<String> get daysWithEntries => monthCategoryMarkers.keys.toSet();
 
-  /// Whether the user has journaled today (based on monthCategoryMarkers).
-  bool get journaledToday {
-    final now = DateTime.now();
-    final todayStr = _dateFormat.format(now);
-    return daysWithEntries.contains(todayStr);
-  }
+  /// Whether the user has journaled today.
+  bool get journaledToday => todayCategoryCounts.isNotEmpty;
 
   List<CategoryEntry> entriesForCategory(String categoryId) {
     return entries.where((e) => e.categoryId == categoryId).toList();
@@ -150,6 +160,7 @@ class JournalState extends Equatable {
     DateTime? selectedDate,
     List<CategoryEntry>? entries,
     Map<String, Map<String, int>>? monthCategoryMarkers,
+    Map<String, int>? todayCategoryCounts,
     int? currentStreak,
     String? lastJournalDate,
     String? error,
@@ -159,6 +170,7 @@ class JournalState extends Equatable {
       selectedDate: selectedDate ?? this.selectedDate,
       entries: entries ?? this.entries,
       monthCategoryMarkers: monthCategoryMarkers ?? this.monthCategoryMarkers,
+      todayCategoryCounts: todayCategoryCounts ?? this.todayCategoryCounts,
       currentStreak: currentStreak ?? this.currentStreak,
       lastJournalDate: lastJournalDate ?? this.lastJournalDate,
       error: error,
@@ -171,6 +183,7 @@ class JournalState extends Equatable {
     selectedDate,
     entries,
     monthCategoryMarkers,
+    todayCategoryCounts,
     currentStreak,
     lastJournalDate,
     error,
@@ -213,6 +226,20 @@ class JournalBloc extends Bloc<JournalEvent, JournalState> {
     Map<String, Map<String, int>> source,
   ) {
     return source.map((k, v) => MapEntry(k, Map<String, int>.from(v)));
+  }
+
+  /// Today's counts from [markers] when ([year], [month]) is the current
+  /// month, else null so copyWith preserves the existing value (#154).
+  Map<String, int>? _todayCountsIfCurrentMonth(
+    Map<String, Map<String, int>> markers,
+    int year,
+    int month,
+  ) {
+    final now = DateTime.now();
+    if (year != now.year || month != now.month) return null;
+    return Map<String, int>.from(
+      markers[JournalState._dateFormat.format(now)] ?? const {},
+    );
   }
 
   Future<void> _onLoadEntries(
@@ -293,6 +320,13 @@ class JournalBloc extends Bloc<JournalEvent, JournalState> {
       state.copyWith(
         status: JournalStatus.loaded,
         monthCategoryMarkers: markers ?? state.monthCategoryMarkers,
+        todayCategoryCounts: markers != null
+            ? _todayCountsIfCurrentMonth(
+                markers,
+                event.date.year,
+                event.date.month,
+              )
+            : null,
         currentStreak: streak?.currentStreak ?? state.currentStreak,
         lastJournalDate: streak?.lastJournalDate ?? state.lastJournalDate,
         error: loadError,
@@ -335,6 +369,11 @@ class JournalBloc extends Bloc<JournalEvent, JournalState> {
         status: JournalStatus.loaded,
         entries: [...state.entries.where((e) => e.id != created.id), created],
         monthCategoryMarkers: currentMarkers,
+        todayCategoryCounts: _todayCountsIfCurrentMonth(
+          currentMarkers,
+          targetDate.year,
+          targetDate.month,
+        ),
         currentStreak: optimisticStreak,
         lastJournalDate: dateString,
       ),
@@ -467,6 +506,11 @@ class JournalBloc extends Bloc<JournalEvent, JournalState> {
         state.copyWith(
           status: JournalStatus.loaded,
           monthCategoryMarkers: currentMarkers,
+          todayCategoryCounts: _todayCountsIfCurrentMonth(
+            currentMarkers,
+            state.selectedDate.year,
+            state.selectedDate.month,
+          ),
         ),
       );
       // Refresh streak in background (non-blocking for UI)
@@ -493,7 +537,17 @@ class JournalBloc extends Bloc<JournalEvent, JournalState> {
     try {
       final key = _cacheKey(event.year, event.month);
       if (_markerCache.containsKey(key)) {
-        emit(state.copyWith(monthCategoryMarkers: _markerCache[key]));
+        final cached = _markerCache[key]!;
+        emit(
+          state.copyWith(
+            monthCategoryMarkers: cached,
+            todayCategoryCounts: _todayCountsIfCurrentMonth(
+              cached,
+              event.year,
+              event.month,
+            ),
+          ),
+        );
         return;
       }
       final markers = await _repository.getMonthCategoryMarkers(
@@ -501,7 +555,16 @@ class JournalBloc extends Bloc<JournalEvent, JournalState> {
         event.month,
       );
       _markerCache[key] = markers;
-      emit(state.copyWith(monthCategoryMarkers: markers));
+      emit(
+        state.copyWith(
+          monthCategoryMarkers: markers,
+          todayCategoryCounts: _todayCountsIfCurrentMonth(
+            markers,
+            event.year,
+            event.month,
+          ),
+        ),
+      );
     } catch (_) {
       // Non-critical — silently fail for markers
     }

--- a/lib/features/daily_journal/bloc/journal_bloc.dart
+++ b/lib/features/daily_journal/bloc/journal_bloc.dart
@@ -241,37 +241,63 @@ class JournalBloc extends Bloc<JournalEvent, JournalState> {
     // Cancel previous date's subscription
     await _entriesSubscription?.cancel();
 
-    try {
-      final dateString = JournalState._dateFormat.format(event.date);
+    final dateString = JournalState._dateFormat.format(event.date);
 
-      // Subscribe to entry stream (cache-first, auto-updates on sync)
-      _entriesSubscription = _repository
-          .watchCategoryEntries(dateString)
-          .listen((entries) => add(_EntriesUpdated(entries)));
+    // Subscribe to entry stream (cache-first, auto-updates on sync)
+    _entriesSubscription = _repository
+        .watchCategoryEntries(dateString)
+        .listen((entries) => add(_EntriesUpdated(entries)));
 
-      // Fetch markers and streak in parallel
-      final results = await Future.wait([
-        _repository.getMonthCategoryMarkers(event.date.year, event.date.month),
-        _repository.getStreakData(),
-      ]);
+    // Fetch markers and streak independently: one failure must not discard
+    // the other's data (#189/#49/#151 — a failing streak query silently
+    // dropped successfully-fetched month markers).
+    String? loadError;
 
-      final markers = results[0] as Map<String, Map<String, int>>;
-      final streak = results[1] as StreakData;
-
-      final key = _cacheKey(event.date.year, event.date.month);
-      _markerCache[key] = markers;
-
-      emit(
-        state.copyWith(
-          status: JournalStatus.loaded,
-          monthCategoryMarkers: markers,
-          currentStreak: streak.currentStreak,
-          lastJournalDate: streak.lastJournalDate,
-        ),
-      );
-    } catch (e) {
-      emit(state.copyWith(status: JournalStatus.error, error: e.toString()));
+    Future<Map<String, Map<String, int>>?> fetchMarkers() async {
+      try {
+        return await _repository.getMonthCategoryMarkers(
+          event.date.year,
+          event.date.month,
+        );
+      } catch (e) {
+        loadError = e.toString();
+        return null;
+      }
     }
+
+    Future<StreakData?> fetchStreak() async {
+      try {
+        return await _repository.getStreakData();
+      } catch (e) {
+        loadError ??= e.toString();
+        return null;
+      }
+    }
+
+    final results = await Future.wait<Object?>([fetchMarkers(), fetchStreak()]);
+    final markers = results[0] as Map<String, Map<String, int>>?;
+    final streak = results[1] as StreakData?;
+
+    if (markers != null) {
+      _markerCache[_cacheKey(event.date.year, event.date.month)] = markers;
+    }
+
+    // Nothing usable loaded → error state; partial data → loaded with the
+    // error surfaced so the UI can show a banner with retry (#170).
+    if (markers == null && streak == null) {
+      emit(state.copyWith(status: JournalStatus.error, error: loadError));
+      return;
+    }
+
+    emit(
+      state.copyWith(
+        status: JournalStatus.loaded,
+        monthCategoryMarkers: markers ?? state.monthCategoryMarkers,
+        currentStreak: streak?.currentStreak ?? state.currentStreak,
+        lastJournalDate: streak?.lastJournalDate ?? state.lastJournalDate,
+        error: loadError,
+      ),
+    );
   }
 
   /// Shared optimistic update for both AddEntry and AddVoiceEntry.
@@ -503,7 +529,15 @@ class JournalBloc extends Bloc<JournalEvent, JournalState> {
     final status = state.status == JournalStatus.saving
         ? JournalStatus.saving
         : JournalStatus.loaded;
-    emit(state.copyWith(status: status, entries: event.entries));
+    // Preserve any pending load error — the cache-first stream otherwise
+    // masks marker/streak failures and the user never sees feedback (#170).
+    emit(
+      state.copyWith(
+        status: status,
+        entries: event.entries,
+        error: state.error,
+      ),
+    );
   }
 
   @override

--- a/lib/features/daily_journal/bloc/journal_bloc.dart
+++ b/lib/features/daily_journal/bloc/journal_bloc.dart
@@ -117,7 +117,13 @@ class JournalState extends Equatable {
   /// Today's per-category entry counts, independent of which month
   /// [monthCategoryMarkers] currently holds. Survives month navigation so
   /// the dashboard (nudge + progress card) always reflects today (#154).
-  final Map<String, int> todayCategoryCounts;
+  /// Stored with the date it was computed for; read through
+  /// [todayCategoryCounts] which returns empty once that date has passed
+  /// (midnight rollover must not show yesterday as "today").
+  final Map<String, int> _todayCategoryCounts;
+
+  /// 'yyyy-MM-dd' the stored counts belong to.
+  final String todayCountsDate;
   final int currentStreak;
   final String? lastJournalDate;
   final String? error;
@@ -130,23 +136,32 @@ class JournalState extends Equatable {
     this.entries = const [],
     this.monthCategoryMarkers = const {},
     Map<String, int>? todayCategoryCounts,
+    String? todayCountsDate,
     this.currentStreak = 0,
     this.lastJournalDate,
     this.error,
   }) : selectedDate = selectedDate ?? DateTime.now(),
        // Derive from markers when not explicitly provided, so directly
        // constructed states (tests, initial load) stay consistent.
-       todayCategoryCounts =
+       _todayCategoryCounts =
            todayCategoryCounts ??
            Map<String, int>.from(
              monthCategoryMarkers[_dateFormat.format(DateTime.now())] ??
                  const {},
-           );
+           ),
+       todayCountsDate = todayCountsDate ?? _dateFormat.format(DateTime.now());
 
   String get selectedDateString => _dateFormat.format(selectedDate);
 
   /// Backward-compatible derived getter — dates that have any entries.
   Set<String> get daysWithEntries => monthCategoryMarkers.keys.toSet();
+
+  /// Today's counts, empty when the stored counts are for a past date
+  /// (midnight rollover).
+  Map<String, int> get todayCategoryCounts =>
+      todayCountsDate == _dateFormat.format(DateTime.now())
+      ? _todayCategoryCounts
+      : const {};
 
   /// Whether the user has journaled today.
   bool get journaledToday => todayCategoryCounts.isNotEmpty;
@@ -170,7 +185,13 @@ class JournalState extends Equatable {
       selectedDate: selectedDate ?? this.selectedDate,
       entries: entries ?? this.entries,
       monthCategoryMarkers: monthCategoryMarkers ?? this.monthCategoryMarkers,
-      todayCategoryCounts: todayCategoryCounts ?? this.todayCategoryCounts,
+      todayCategoryCounts: todayCategoryCounts ?? _todayCategoryCounts,
+      // Fresh counts are always computed "for now" — restamp their date.
+      // Preserved counts keep their original date so the rollover gate
+      // in the getter stays correct.
+      todayCountsDate: todayCategoryCounts != null
+          ? JournalState._dateFormat.format(DateTime.now())
+          : todayCountsDate,
       currentStreak: currentStreak ?? this.currentStreak,
       lastJournalDate: lastJournalDate ?? this.lastJournalDate,
       error: error,
@@ -183,7 +204,8 @@ class JournalState extends Equatable {
     selectedDate,
     entries,
     monthCategoryMarkers,
-    todayCategoryCounts,
+    _todayCategoryCounts,
+    todayCountsDate,
     currentStreak,
     lastJournalDate,
     error,
@@ -364,16 +386,21 @@ class JournalBloc extends Bloc<JournalEvent, JournalState> {
       optimisticStreak = state.currentStreak + 1;
     }
 
+    // Increment today's counts from their current value — the marker map
+    // may hold a different month after calendar navigation, so deriving
+    // from it would wipe today's other categories (review finding, #154).
+    Map<String, int>? todayCounts;
+    if (dateString == JournalState._dateFormat.format(DateTime.now())) {
+      todayCounts = Map<String, int>.from(state.todayCategoryCounts);
+      todayCounts[categoryId] = (todayCounts[categoryId] ?? 0) + 1;
+    }
+
     emit(
       state.copyWith(
         status: JournalStatus.loaded,
         entries: [...state.entries.where((e) => e.id != created.id), created],
         monthCategoryMarkers: currentMarkers,
-        todayCategoryCounts: _todayCountsIfCurrentMonth(
-          currentMarkers,
-          targetDate.year,
-          targetDate.month,
-        ),
+        todayCategoryCounts: todayCounts,
         currentStreak: optimisticStreak,
         lastJournalDate: dateString,
       ),
@@ -502,15 +529,25 @@ class JournalBloc extends Bloc<JournalEvent, JournalState> {
       );
       _markerCache[focusKey] = currentMarkers;
 
+      // Decrement today's counts from their current value, not from the
+      // marker map (which may hold another month — review finding, #154).
+      Map<String, int>? todayCounts;
+      if (dateStr == JournalState._dateFormat.format(DateTime.now()) &&
+          deletedEntry != null) {
+        todayCounts = Map<String, int>.from(state.todayCategoryCounts);
+        final count = (todayCounts[deletedEntry.categoryId] ?? 1) - 1;
+        if (count <= 0) {
+          todayCounts.remove(deletedEntry.categoryId);
+        } else {
+          todayCounts[deletedEntry.categoryId] = count;
+        }
+      }
+
       emit(
         state.copyWith(
           status: JournalStatus.loaded,
           monthCategoryMarkers: currentMarkers,
-          todayCategoryCounts: _todayCountsIfCurrentMonth(
-            currentMarkers,
-            state.selectedDate.year,
-            state.selectedDate.month,
-          ),
+          todayCategoryCounts: todayCounts,
         ),
       );
       // Refresh streak in background (non-blocking for UI)

--- a/lib/features/daily_journal/home_screen.dart
+++ b/lib/features/daily_journal/home_screen.dart
@@ -6,7 +6,6 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:intl/intl.dart';
 import 'package:table_calendar/table_calendar.dart';
 import 'package:dytty/data/models/category_config.dart';
-import 'package:dytty/data/models/category_entry.dart';
 import 'package:dytty/features/auth/bloc/auth_bloc.dart';
 import 'package:dytty/features/daily_journal/bloc/journal_bloc.dart';
 import 'package:dytty/features/settings/cubit/category_cubit.dart';
@@ -154,6 +153,27 @@ class _HomeScreenState extends State<HomeScreen> {
                     .animate()
                     .fadeIn(duration: 400.ms)
                     .slideX(begin: -0.05, end: 0, duration: 400.ms),
+
+                // Load failure feedback with retry (#170)
+                if (journalState.error != null)
+                  MaterialBanner(
+                    leading: Icon(
+                      Icons.cloud_off_rounded,
+                      color: theme.colorScheme.error,
+                    ),
+                    content: const Text("Couldn't load your journal data."),
+                    actions: [
+                      TextButton(
+                        onPressed: () => context.read<JournalBloc>().add(
+                          SelectDate(journalState.selectedDate),
+                        ),
+                        child: const Text('Retry'),
+                      ),
+                    ],
+                  ),
+
+                if (journalState.status == JournalStatus.loading)
+                  const LinearProgressIndicator(minHeight: 2),
 
                 // Calendar
                 Padding(
@@ -304,9 +324,11 @@ class _HomeScreenState extends State<HomeScreen> {
                 Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 16),
                       child: _ProgressCard(
-                        entries: journalState.entries,
+                        // Always today's status, independent of the
+                        // selected date (#154).
+                        filledCategoryIds: journalState.todayCategoryCounts.keys
+                            .toSet(),
                         categories: categoryState.activeCategories,
-                        selectedDate: journalState.selectedDate,
                         currentStreak: journalState.currentStreak,
                         onCategoryTap: (categoryId) {
                           Navigator.pushNamed(
@@ -602,16 +624,14 @@ class _InitialsAvatar extends StatelessWidget {
 }
 
 class _ProgressCard extends StatelessWidget {
-  final List<CategoryEntry> entries;
+  final Set<String> filledCategoryIds;
   final List<CategoryConfig> categories;
   final int currentStreak;
-  final DateTime selectedDate;
   final void Function(String categoryId)? onCategoryTap;
 
   const _ProgressCard({
-    required this.entries,
+    required this.filledCategoryIds,
     required this.categories,
-    required this.selectedDate,
     this.currentStreak = 0,
     this.onCategoryTap,
   });
@@ -619,10 +639,6 @@ class _ProgressCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final filledCategoryIds = <String>{};
-    for (final entry in entries) {
-      filledCategoryIds.add(entry.categoryId);
-    }
     final total = categories.length;
     final filled = filledCategoryIds
         .intersection(categories.map((c) => c.id).toSet())
@@ -651,9 +667,7 @@ class _ProgressCard extends StatelessWidget {
               Row(
                 children: [
                   Text(
-                    isSameDay(selectedDate, DateTime.now())
-                        ? "Today's Progress"
-                        : '${DateFormat('MMM d').format(selectedDate)} Progress',
+                    "Today's Progress",
                     style: theme.textTheme.titleSmall?.copyWith(
                       fontWeight: FontWeight.w600,
                     ),

--- a/test/features/daily_journal/journal_bloc_test.dart
+++ b/test/features/daily_journal/journal_bloc_test.dart
@@ -1012,4 +1012,101 @@ void main() {
       ],
     );
   });
+
+  group('JournalBloc SelectDate resilience (#189/#49/#151/#170)', () {
+    late MockJournalRepository mockRepository;
+
+    const streak = StreakData(
+      currentStreak: 2,
+      longestStreak: 4,
+      lastJournalDate: '2026-03-01',
+    );
+    final markers = {
+      '2026-03-01': {'positive': 1},
+    };
+
+    setUp(() {
+      mockRepository = MockJournalRepository();
+    });
+
+    blocTest<JournalBloc, JournalState>(
+      'applies markers and surfaces error when getStreakData throws',
+      setUp: () {
+        when(
+          () => mockRepository.watchCategoryEntries(any()),
+        ).thenAnswer((_) => const Stream.empty());
+        when(
+          () => mockRepository.getMonthCategoryMarkers(any(), any()),
+        ).thenAnswer((_) async => markers);
+        when(
+          () => mockRepository.getStreakData(),
+        ).thenThrow(Exception('FAILED_PRECONDITION: index missing'));
+      },
+      build: () => JournalBloc(repository: mockRepository),
+      act: (bloc) => bloc.add(SelectDate(DateTime(2026, 3, 1))),
+      verify: (bloc) {
+        expect(bloc.state.status, JournalStatus.loaded);
+        expect(bloc.state.monthCategoryMarkers, markers);
+        expect(bloc.state.error, contains('FAILED_PRECONDITION'));
+      },
+    );
+
+    blocTest<JournalBloc, JournalState>(
+      'applies streak and surfaces error when getMonthCategoryMarkers throws',
+      setUp: () {
+        when(
+          () => mockRepository.watchCategoryEntries(any()),
+        ).thenAnswer((_) => const Stream.empty());
+        when(
+          () => mockRepository.getMonthCategoryMarkers(any(), any()),
+        ).thenThrow(Exception('markers failed'));
+        when(
+          () => mockRepository.getStreakData(),
+        ).thenAnswer((_) async => streak);
+      },
+      build: () => JournalBloc(repository: mockRepository),
+      act: (bloc) => bloc.add(SelectDate(DateTime(2026, 3, 1))),
+      verify: (bloc) {
+        expect(bloc.state.status, JournalStatus.loaded);
+        expect(bloc.state.currentStreak, 2);
+        expect(bloc.state.lastJournalDate, '2026-03-01');
+        expect(bloc.state.error, contains('markers failed'));
+      },
+    );
+
+    blocTest<JournalBloc, JournalState>(
+      'entry stream emission does not clear a pending load error',
+      setUp: () {
+        when(() => mockRepository.watchCategoryEntries(any())).thenAnswer(
+          (_) => Stream.value([
+            CategoryEntry(
+              id: 'e1',
+              categoryId: 'positive',
+              text: 'cached entry',
+              createdAt: DateTime(2026, 3, 1),
+            ),
+          ]),
+        );
+        when(
+          () => mockRepository.getMonthCategoryMarkers(any(), any()),
+        ).thenThrow(Exception('markers failed'));
+        when(
+          () => mockRepository.getStreakData(),
+        ).thenAnswer((_) async => streak);
+      },
+      build: () => JournalBloc(repository: mockRepository),
+      act: (bloc) async {
+        bloc.add(SelectDate(DateTime(2026, 3, 1)));
+        await Future.delayed(const Duration(milliseconds: 100));
+      },
+      verify: (bloc) {
+        expect(bloc.state.entries.length, 1);
+        expect(
+          bloc.state.error,
+          contains('markers failed'),
+          reason: 'stream emits must not mask load errors (#170)',
+        );
+      },
+    );
+  });
 }

--- a/test/features/daily_journal/journal_bloc_test.dart
+++ b/test/features/daily_journal/journal_bloc_test.dart
@@ -1189,6 +1189,74 @@ void main() {
       },
     );
 
+    test('counts dated before today read as empty (midnight rollover)', () {
+      final state = JournalState(
+        todayCategoryCounts: const {'positive': 2},
+        todayCountsDate: '2020-01-01',
+      );
+      expect(state.todayCategoryCounts, isEmpty);
+      expect(state.journaledToday, false);
+    });
+
+    blocTest<JournalBloc, JournalState>(
+      'optimistic AddEntry preserves today counts when markers hold '
+      'another month',
+      build: () => JournalBloc(repository: repository),
+      // Calendar was swiped to another month: marker map is NOT today's
+      // month, but today already has a gratitude entry.
+      seed: () => JournalState(
+        selectedDate: today,
+        monthCategoryMarkers: {
+          '2020-01-05': {'beauty': 1},
+        },
+        todayCategoryCounts: const {'gratitude': 1},
+      ),
+      act: (bloc) async {
+        bloc.add(const AddEntry(categoryId: 'positive', text: 'new today'));
+        await Future.delayed(const Duration(milliseconds: 200));
+      },
+      verify: (bloc) {
+        expect(bloc.state.todayCategoryCounts['positive'], 1);
+        expect(
+          bloc.state.todayCategoryCounts['gratitude'],
+          1,
+          reason: 'must not re-derive from the stale other-month map',
+        );
+      },
+    );
+
+    blocTest<JournalBloc, JournalState>(
+      'optimistic DeleteEntry decrements today counts without the '
+      'current-month marker map',
+      build: () => JournalBloc(repository: repository),
+      setUp: () async {
+        await repository.addCategoryEntry(todayStr, 'positive', 'kill me');
+      },
+      seed: () => JournalState(
+        selectedDate: today,
+        monthCategoryMarkers: {
+          '2020-01-05': {'beauty': 1},
+        },
+        todayCategoryCounts: const {'positive': 1, 'gratitude': 1},
+      ),
+      act: (bloc) async {
+        // Load entries so the bloc knows the entry id, then delete it.
+        bloc.add(const LoadEntries());
+        await Future.delayed(const Duration(milliseconds: 200));
+        bloc.add(DeleteEntry(bloc.state.entries.first.id));
+        await Future.delayed(const Duration(milliseconds: 200));
+      },
+      verify: (bloc) {
+        expect(bloc.state.todayCategoryCounts.containsKey('positive'), false);
+        expect(
+          bloc.state.todayCategoryCounts['gratitude'],
+          1,
+          reason: 'unrelated category must survive the delete',
+        );
+        expect(bloc.state.journaledToday, true);
+      },
+    );
+
     blocTest<JournalBloc, JournalState>(
       'updated by optimistic AddEntry for today',
       build: () => JournalBloc(repository: repository),

--- a/test/features/daily_journal/journal_bloc_test.dart
+++ b/test/features/daily_journal/journal_bloc_test.dart
@@ -1109,4 +1109,100 @@ void main() {
       },
     );
   });
+
+  group('todayCategoryCounts (#154)', () {
+    late MockJournalRepository mockRepository;
+
+    final today = DateTime.now();
+    final todayStr =
+        '${today.year}-${today.month.toString().padLeft(2, '0')}-${today.day.toString().padLeft(2, '0')}';
+
+    setUp(() {
+      mockRepository = MockJournalRepository();
+    });
+
+    test('derived from monthCategoryMarkers when constructed directly', () {
+      final state = JournalState(
+        monthCategoryMarkers: {
+          todayStr: {'positive': 2, 'gratitude': 1},
+        },
+      );
+      expect(state.todayCategoryCounts, {'positive': 2, 'gratitude': 1});
+      expect(state.journaledToday, true);
+    });
+
+    blocTest<JournalBloc, JournalState>(
+      'refreshed when SelectDate loads the month containing today',
+      setUp: () {
+        when(
+          () => mockRepository.watchCategoryEntries(any()),
+        ).thenAnswer((_) => const Stream.empty());
+        when(
+          () => mockRepository.getMonthCategoryMarkers(any(), any()),
+        ).thenAnswer(
+          (_) async => {
+            todayStr: {'positive': 1},
+          },
+        );
+        when(() => mockRepository.getStreakData()).thenAnswer(
+          (_) async => const StreakData(
+            currentStreak: 1,
+            longestStreak: 1,
+            lastJournalDate: null,
+          ),
+        );
+      },
+      build: () => JournalBloc(repository: mockRepository),
+      act: (bloc) => bloc.add(SelectDate(today)),
+      verify: (bloc) {
+        expect(bloc.state.todayCategoryCounts, {'positive': 1});
+        expect(bloc.state.journaledToday, true);
+      },
+    );
+
+    blocTest<JournalBloc, JournalState>(
+      'preserved when LoadMonthMarkers swaps to a different month',
+      setUp: () {
+        when(() => mockRepository.getMonthCategoryMarkers(2025, 1)).thenAnswer(
+          (_) async => {
+            '2025-01-05': {'beauty': 1},
+          },
+        );
+      },
+      build: () => JournalBloc(repository: mockRepository),
+      seed: () => JournalState(
+        monthCategoryMarkers: {
+          todayStr: {'positive': 1},
+        },
+      ),
+      act: (bloc) => bloc.add(const LoadMonthMarkers(year: 2025, month: 1)),
+      verify: (bloc) {
+        expect(bloc.state.monthCategoryMarkers, {
+          '2025-01-05': {'beauty': 1},
+        });
+        expect(
+          bloc.state.todayCategoryCounts,
+          {'positive': 1},
+          reason: 'today counts must survive month navigation (#154)',
+        );
+        expect(bloc.state.journaledToday, true);
+      },
+    );
+
+    blocTest<JournalBloc, JournalState>(
+      'updated by optimistic AddEntry for today',
+      build: () => JournalBloc(repository: repository),
+      seed: () => JournalState(selectedDate: today),
+      act: (bloc) async {
+        bloc.add(SelectDate(today));
+        await Future.delayed(const Duration(milliseconds: 200));
+        bloc.add(const AddEntry(categoryId: 'positive', text: 'today entry'));
+        await Future.delayed(const Duration(milliseconds: 200));
+      },
+      verify: (bloc) {
+        expect(bloc.state.todayCategoryCounts['positive'], 1);
+        expect(bloc.state.journaledToday, true);
+      },
+    );
+  });
 }

--- a/test/widgets/home_screen_test.dart
+++ b/test/widgets/home_screen_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:intl/intl.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:dytty/data/models/category_config.dart';
 import 'package:dytty/data/models/category_entry.dart';
 import 'package:dytty/features/auth/bloc/auth_bloc.dart';
@@ -79,20 +80,7 @@ void main() {
         const HomeScreen(),
         journalState: JournalState(
           status: JournalStatus.loaded,
-          entries: [
-            CategoryEntry(
-              id: 'e1',
-              categoryId: 'positive',
-              text: 'Good day',
-              createdAt: DateTime.now(),
-            ),
-            CategoryEntry(
-              id: 'e2',
-              categoryId: 'gratitude',
-              text: 'Thankful',
-              createdAt: DateTime.now(),
-            ),
-          ],
+          todayCategoryCounts: const {'positive': 1, 'gratitude': 1},
         ),
         categoryState: CategoryState(
           categories: CategoryConfig.defaults,
@@ -104,6 +92,92 @@ void main() {
       robot = HomeScreenRobot(tester);
       // 2 categories filled out of 5 defaults
       robot.expectProgressVisible(2, 5);
+    });
+
+    testWidgets('progress card shows today counts when a past date is '
+        'selected (#154)', (tester) async {
+      final pastDate = DateTime.now().subtract(const Duration(days: 10));
+      await tester.pumpApp(
+        const HomeScreen(),
+        journalState: JournalState(
+          status: JournalStatus.loaded,
+          selectedDate: pastDate,
+          // Selected (past) date has a single entry loaded...
+          entries: [
+            CategoryEntry(
+              id: 'e1',
+              categoryId: 'positive',
+              text: 'Old entry',
+              createdAt: pastDate,
+            ),
+          ],
+          // ...but today has 3 filled categories.
+          todayCategoryCounts: const {
+            'positive': 1,
+            'gratitude': 2,
+            'beauty': 1,
+          },
+        ),
+        categoryState: CategoryState(
+          categories: CategoryConfig.defaults,
+          loaded: true,
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      robot = HomeScreenRobot(tester);
+      // Dashboard reflects today (3/5), not the selected date (1/5).
+      robot.expectProgressVisible(3, 5);
+      expect(find.text("Today's Progress"), findsOneWidget);
+    });
+
+    testWidgets('shows error banner with retry when load failed (#170)', (
+      tester,
+    ) async {
+      await tester.pumpApp(
+        const HomeScreen(),
+        journalState: JournalState(
+          status: JournalStatus.loaded,
+          error: 'FAILED_PRECONDITION: index missing',
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(find.textContaining("Couldn't load"), findsOneWidget);
+      expect(find.text('Retry'), findsOneWidget);
+    });
+
+    testWidgets('tapping retry dispatches SelectDate for the selected date', (
+      tester,
+    ) async {
+      final selected = DateTime(2026, 6, 1);
+      final journalBloc = MockJournalBloc();
+
+      await tester.pumpApp(
+        const HomeScreen(),
+        journalBloc: journalBloc,
+        journalState: JournalState(
+          status: JournalStatus.loaded,
+          selectedDate: selected,
+          error: 'network down',
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      await tester.tap(find.text('Retry'));
+      await tester.pump();
+
+      verify(() => journalBloc.add(SelectDate(selected))).called(1);
+    });
+
+    testWidgets('no error banner when error is null', (tester) async {
+      await tester.pumpApp(
+        const HomeScreen(),
+        journalState: JournalState(status: JournalStatus.loaded),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(find.text('Retry'), findsNothing);
     });
 
     testWidgets('mic FAB is present', (tester) async {
@@ -170,26 +244,11 @@ void main() {
         const HomeScreen(),
         journalState: JournalState(
           status: JournalStatus.loaded,
-          entries: [
-            CategoryEntry(
-              id: 'e1',
-              categoryId: 'positive',
-              text: 'Good',
-              createdAt: DateTime.now(),
-            ),
-            CategoryEntry(
-              id: 'e2',
-              categoryId: 'gratitude',
-              text: 'Thanks',
-              createdAt: DateTime.now(),
-            ),
-            CategoryEntry(
-              id: 'e3',
-              categoryId: 'beauty',
-              text: 'Sunset',
-              createdAt: DateTime.now(),
-            ),
-          ],
+          todayCategoryCounts: const {
+            'positive': 1,
+            'gratitude': 1,
+            'beauty': 1,
+          },
         ),
         categoryState: CategoryState(
           categories: CategoryConfig.defaults,
@@ -207,38 +266,13 @@ void main() {
         const HomeScreen(),
         journalState: JournalState(
           status: JournalStatus.loaded,
-          entries: [
-            CategoryEntry(
-              id: 'e1',
-              categoryId: 'positive',
-              text: 'Good',
-              createdAt: DateTime.now(),
-            ),
-            CategoryEntry(
-              id: 'e2',
-              categoryId: 'negative',
-              text: 'Bad',
-              createdAt: DateTime.now(),
-            ),
-            CategoryEntry(
-              id: 'e3',
-              categoryId: 'gratitude',
-              text: 'Thanks',
-              createdAt: DateTime.now(),
-            ),
-            CategoryEntry(
-              id: 'e4',
-              categoryId: 'beauty',
-              text: 'Sunset',
-              createdAt: DateTime.now(),
-            ),
-            CategoryEntry(
-              id: 'e5',
-              categoryId: 'identity',
-              text: 'Growth',
-              createdAt: DateTime.now(),
-            ),
-          ],
+          todayCategoryCounts: const {
+            'positive': 1,
+            'negative': 1,
+            'gratitude': 1,
+            'beauty': 1,
+            'identity': 1,
+          },
         ),
         categoryState: CategoryState(
           categories: CategoryConfig.defaults,
@@ -335,38 +369,13 @@ void main() {
         const HomeScreen(),
         journalState: JournalState(
           status: JournalStatus.loaded,
-          entries: [
-            CategoryEntry(
-              id: 'e1',
-              categoryId: 'positive',
-              text: 'Good',
-              createdAt: DateTime.now(),
-            ),
-            CategoryEntry(
-              id: 'e2',
-              categoryId: 'negative',
-              text: 'Bad',
-              createdAt: DateTime.now(),
-            ),
-            CategoryEntry(
-              id: 'e3',
-              categoryId: 'gratitude',
-              text: 'Thanks',
-              createdAt: DateTime.now(),
-            ),
-            CategoryEntry(
-              id: 'e4',
-              categoryId: 'beauty',
-              text: 'Sunset',
-              createdAt: DateTime.now(),
-            ),
-            CategoryEntry(
-              id: 'e5',
-              categoryId: 'identity',
-              text: 'Growth',
-              createdAt: DateTime.now(),
-            ),
-          ],
+          todayCategoryCounts: const {
+            'positive': 1,
+            'negative': 1,
+            'gratitude': 1,
+            'beauty': 1,
+            'identity': 1,
+          },
         ),
         categoryState: CategoryState(
           categories: CategoryConfig.defaults,
@@ -385,14 +394,7 @@ void main() {
         const HomeScreen(),
         journalState: JournalState(
           status: JournalStatus.loaded,
-          entries: [
-            CategoryEntry(
-              id: 'e1',
-              categoryId: 'positive',
-              text: 'Good',
-              createdAt: DateTime.now(),
-            ),
-          ],
+          todayCategoryCounts: const {'positive': 1},
         ),
         categoryState: CategoryState(
           categories: CategoryConfig.defaults,
@@ -412,32 +414,12 @@ void main() {
         const HomeScreen(),
         journalState: JournalState(
           status: JournalStatus.loaded,
-          entries: [
-            CategoryEntry(
-              id: 'e1',
-              categoryId: 'positive',
-              text: 'Good',
-              createdAt: DateTime.now(),
-            ),
-            CategoryEntry(
-              id: 'e2',
-              categoryId: 'negative',
-              text: 'Bad',
-              createdAt: DateTime.now(),
-            ),
-            CategoryEntry(
-              id: 'e3',
-              categoryId: 'gratitude',
-              text: 'Thanks',
-              createdAt: DateTime.now(),
-            ),
-            CategoryEntry(
-              id: 'e4',
-              categoryId: 'beauty',
-              text: 'Sunset',
-              createdAt: DateTime.now(),
-            ),
-          ],
+          todayCategoryCounts: const {
+            'positive': 1,
+            'negative': 1,
+            'gratitude': 1,
+            'beauty': 1,
+          },
         ),
         categoryState: CategoryState(
           categories: CategoryConfig.defaults,


### PR DESCRIPTION
## Summary

Fixes the chronic stale-state-on-restart family. Root cause chain (diagnosed on Pixel 9a, logcat evidence in commits):

1. `getStreakData()` ordered `dailyEntries` by `__name__ DESC` — requires a composite index that was **never deployed** → `FAILED_PRECONDITION` on every cold start.
2. The failing streak future shared a `Future.wait` with the markers fetch in `_onSelectDate` → successfully-fetched month markers were silently discarded → empty calendar rings, grey icons, `journaledToday=false`.
3. The cache-first entries stream then flipped status back to `loaded`, masking the error — no user feedback.
4. Bonus: `firestore.rules` had no match for `users/{uid}/categories` → `PERMISSION_DENIED` on every CategoryCubit fetch (silent default fallback).

Fixes #189
Fixes #49
Fixes #151
Fixes #154
Fixes #170

## Key Decisions

- **Removed the orderBy instead of deploying the index** — doc IDs land in a `Set` and are re-sorted client-side; server ordering was dead weight. One less index to manage.
- **Per-fetch try/catch over shared `Future.wait` rejection** — partial data is applied; both failing → `error` status (preserves existing semantics), one failing → `loaded` + `error` surfaced.
- **`_EntriesUpdated` preserves `state.error`** so stream emits can't mask load failures.
- **New `JournalState.todayCategoryCounts`** — today-scoped counts that survive month navigation; nudge card and progress card now share one today-source (#154). Progress card title fixed to "Today's Progress".
- **Inline `MaterialBanner` + Retry** (state-driven, testable) for load failures; thin `LinearProgressIndicator` while loading.
- **Rules fix requires deploy**: `firebase deploy --only firestore:rules` (pending owner approval).

## Test Plan

- [x] 3 new bloc tests reproducing the marker-discard + error-masking bugs (failed before fix)
- [x] 4 new bloc tests for `todayCategoryCounts` month-navigation behavior
- [x] 4 new HomeScreen widget tests (today-sourced card, banner, retry dispatch)
- [x] New Maestro flow `state/data-loads-after-restart.yaml` (kill + relaunch, no interaction)
- [x] Full suite: 806 tests green, `flutter analyze` clean (7 pre-existing infos)
- [x] **Device-verified on Pixel 9a**: cold start shows completion rings immediately, zero `FAILED_PRECONDITION` in logcat

## Tester Checklist

- [ ] Add an entry, fully close the app, reopen — calendar rings, category icons and streak appear immediately without tapping anything
- [ ] Tap a past date — the "Today's Progress" card keeps showing today's progress
- [ ] Turn on airplane mode, reopen the app — an error banner with Retry appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)