### PR TITLE
fix(voice): always-visible cancel button on voice entry sheet (#187)

### DIFF
--- a/lib/features/voice_note/widgets/voice_recording_sheet.dart
+++ b/lib/features/voice_note/widgets/voice_recording_sheet.dart
@@ -63,8 +63,10 @@ class _VoiceRecordingSheetBody extends StatelessWidget {
                     children: [
                       // Drag handle + always-visible cancel — swipe-down is
                       // not discoverable, user must never be trapped (#187).
+                      // 48 keeps the IconButton at the Material minimum
+                      // touch target.
                       SizedBox(
-                        height: 40,
+                        height: 48,
                         child: Stack(
                           alignment: Alignment.center,
                           children: [

--- a/lib/features/voice_note/widgets/voice_recording_sheet.dart
+++ b/lib/features/voice_note/widgets/voice_recording_sheet.dart
@@ -61,18 +61,36 @@ class _VoiceRecordingSheetBody extends StatelessWidget {
                   return Column(
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      // Drag handle
-                      Container(
-                        width: 40,
-                        height: 4,
-                        decoration: BoxDecoration(
-                          color: Theme.of(
-                            context,
-                          ).colorScheme.onSurfaceVariant.withValues(alpha: 0.3),
-                          borderRadius: BorderRadius.circular(2),
+                      // Drag handle + always-visible cancel — swipe-down is
+                      // not discoverable, user must never be trapped (#187).
+                      SizedBox(
+                        height: 40,
+                        child: Stack(
+                          alignment: Alignment.center,
+                          children: [
+                            Container(
+                              width: 40,
+                              height: 4,
+                              decoration: BoxDecoration(
+                                color: Theme.of(context)
+                                    .colorScheme
+                                    .onSurfaceVariant
+                                    .withValues(alpha: 0.3),
+                                borderRadius: BorderRadius.circular(2),
+                              ),
+                            ),
+                            Align(
+                              alignment: Alignment.centerRight,
+                              child: IconButton(
+                                tooltip: 'Cancel voice note',
+                                icon: const Icon(Icons.close_rounded),
+                                onPressed: () => Navigator.pop(context),
+                              ),
+                            ),
+                          ],
                         ),
                       ),
-                      const SizedBox(height: 16),
+                      const SizedBox(height: 8),
                       _buildTitle(context, state),
                       const SizedBox(height: 24),
                       _buildContent(context, state),

--- a/test/widgets/voice_recording_sheet_test.dart
+++ b/test/widgets/voice_recording_sheet_test.dart
@@ -400,7 +400,10 @@ void main() {
     testWidgets('tapping a different category chip selects it', (tester) async {
       await openSheetToReviewing(tester, category: 'positive');
 
-      // Tap the "Gratitude" chip
+      // Scroll the chip into view (sheet content sits lower since the
+      // cancel header was added) and tap it.
+      await tester.ensureVisible(find.text('Gratitude'));
+      await tester.pump();
       await tester.tap(find.text('Gratitude'));
       await tester.pump();
 
@@ -545,6 +548,71 @@ void main() {
 
       expect(find.text('Something went wrong'), findsOneWidget);
       expect(find.textContaining('Failed to categorize'), findsOneWidget);
+    });
+  });
+
+  group('cancel button (#187)', () {
+    testWidgets('visible in unavailable state', (tester) async {
+      await openSheet(tester);
+
+      expect(find.byTooltip('Cancel voice note'), findsOneWidget);
+    });
+
+    testWidgets('visible in error state', (tester) async {
+      when(() => mockStt.initialize()).thenThrow(Exception('STT failed'));
+
+      await openSheet(tester);
+
+      expect(find.text('Something went wrong'), findsOneWidget);
+      expect(find.byTooltip('Cancel voice note'), findsOneWidget);
+    });
+
+    testWidgets('visible in listening state', (tester) async {
+      when(() => mockStt.initialize()).thenAnswer((_) async => true);
+      when(
+        () => mockStt.listen(
+          onResult: any(named: 'onResult'),
+          pauseFor: any(named: 'pauseFor'),
+          listenFor: any(named: 'listenFor'),
+        ),
+      ).thenAnswer((_) async {});
+
+      await openSheet(tester);
+
+      expect(find.text('Listening...'), findsOneWidget);
+      expect(find.byTooltip('Cancel voice note'), findsOneWidget);
+
+      // Flush flutter_animate timers before teardown.
+      await tester.pump(const Duration(seconds: 1));
+    });
+
+    testWidgets('visible in transcriptReview state', (tester) async {
+      await openSheetToTranscriptReview(tester, 'today was a good day');
+
+      expect(find.text('Review transcript'), findsOneWidget);
+      expect(find.byTooltip('Cancel voice note'), findsOneWidget);
+    });
+
+    testWidgets('tapping cancel dismisses sheet without a result', (
+      tester,
+    ) async {
+      when(() => mockStt.initialize()).thenAnswer((_) async => true);
+      when(
+        () => mockStt.listen(
+          onResult: any(named: 'onResult'),
+          pauseFor: any(named: 'pauseFor'),
+          listenFor: any(named: 'listenFor'),
+        ),
+      ).thenAnswer((_) async {});
+
+      await openSheet(tester);
+      expect(find.text('Listening...'), findsOneWidget);
+
+      await tester.tap(find.byTooltip('Cancel voice note'));
+      await tester.pumpAndSettle();
+
+      // Sheet dismissed mid-recording — user is never trapped (#187).
+      expect(find.text('Listening...'), findsNothing);
     });
   });
 }

--- a/test/widgets/voice_recording_sheet_test.dart
+++ b/test/widgets/voice_recording_sheet_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:dytty/data/models/category_config.dart';
 import 'package:dytty/features/settings/cubit/category_cubit.dart';
+import 'package:dytty/features/voice_note/voice_note_result.dart';
 import 'package:dytty/features/voice_note/widgets/voice_recording_sheet.dart';
 import 'package:dytty/services/llm/llm_service.dart';
 import 'package:dytty/services/speech/speech_service.dart';
@@ -593,7 +594,74 @@ void main() {
       expect(find.byTooltip('Cancel voice note'), findsOneWidget);
     });
 
-    testWidgets('tapping cancel dismisses sheet without a result', (
+    testWidgets('visible in initial state', (tester) async {
+      // Initialization never completes — sheet stays in initial.
+      when(
+        () => mockStt.initialize(),
+      ).thenAnswer((_) => Completer<bool>().future);
+
+      await openSheet(tester);
+
+      expect(find.text('Initializing...'), findsOneWidget);
+      expect(find.byTooltip('Cancel voice note'), findsOneWidget);
+    });
+
+    testWidgets('visible in processing state', (tester) async {
+      await openSheetToTranscriptReview(tester, 'a long day at work');
+
+      // Completer holds the sheet in processing until we release it.
+      final completer = Completer<CategorizationResult>();
+      when(
+        () => mockLlm.categorizeEntry(
+          any(),
+          categoryIds: any(named: 'categoryIds'),
+        ),
+      ).thenAnswer((_) => completer.future);
+
+      await tester.tap(find.text('Summarize'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      expect(find.text('Processing...'), findsOneWidget);
+      expect(find.byTooltip('Cancel voice note'), findsOneWidget);
+
+      // Release the future so teardown has no pending work.
+      completer.complete(
+        const CategorizationResult(
+          suggestedCategory: 'positive',
+          summary: 'Long day',
+          confidence: 0.9,
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+    });
+
+    testWidgets('visible in reviewing state', (tester) async {
+      await openSheetToTranscriptReview(tester, 'a long day at work');
+
+      when(
+        () => mockLlm.categorizeEntry(
+          any(),
+          categoryIds: any(named: 'categoryIds'),
+        ),
+      ).thenAnswer(
+        (_) async => CategorizationResult(
+          suggestedCategory: 'positive',
+          summary: 'Long day',
+          confidence: 0.9,
+          suggestedTags: const ['work'],
+        ),
+      );
+
+      await tester.tap(find.text('Summarize'));
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(find.text('Review your note'), findsOneWidget);
+      expect(find.byTooltip('Cancel voice note'), findsOneWidget);
+    });
+
+    testWidgets('tapping cancel resolves with null and releases the mic', (
       tester,
     ) async {
       when(() => mockStt.initialize()).thenAnswer((_) async => true);
@@ -605,14 +673,46 @@ void main() {
         ),
       ).thenAnswer((_) async {});
 
-      await openSheet(tester);
+      // Inline variant of openSheet that captures the sheet's result future.
+      Future<VoiceNoteResult?>? resultFuture;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MultiRepositoryProvider(
+            providers: [
+              RepositoryProvider<SpeechService>(
+                create: (_) => SpeechService(speech: mockStt),
+              ),
+              RepositoryProvider<LlmService>(create: (_) => mockLlm),
+            ],
+            child: BlocProvider<CategoryCubit>.value(
+              value: mockCategoryCubit,
+              child: Builder(
+                builder: (context) => Scaffold(
+                  body: ElevatedButton(
+                    onPressed: () =>
+                        resultFuture = showVoiceRecordingSheet(context),
+                    child: const Text('Open'),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('Open'));
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
       expect(find.text('Listening...'), findsOneWidget);
 
       await tester.tap(find.byTooltip('Cancel voice note'));
       await tester.pumpAndSettle();
 
-      // Sheet dismissed mid-recording — user is never trapped (#187).
+      // Sheet dismissed mid-recording, host route intact, null result so
+      // the caller saves nothing, and the mic is released (#187).
       expect(find.text('Listening...'), findsNothing);
+      expect(find.text('Open'), findsOneWidget);
+      await expectLater(resultFuture, completion(isNull));
+      verify(() => mockStt.cancel()).called(greaterThanOrEqualTo(1));
     });
   });
 }


### PR DESCRIPTION
## Summary

The voice entry sheet had no visible exit affordance — swipe-down was the only way out and it is not discoverable, trapping users who opened the sheet by accident.

Adds a close button overlaid on the drag-handle header, present in **every** `VoiceNoteBloc` state, popping the sheet with no result (same discard semantics as existing Discard buttons).

Fixes #187

## Key Decisions

- Button lives in the header above the state-switched content, so no per-state wiring is needed and future states inherit it automatically.
- `Navigator.pop(context)` without a result — `showVoiceRecordingSheet` already treats null as discard.

## Test Plan

- [x] 5 new widget tests: visible in unavailable/error/listening/transcriptReview states + dismiss-without-result (all failed before fix)
- [x] Full suite green, `flutter analyze` clean (7 pre-existing infos)
- [x] Device check on Pixel 9a (see screenshot)

## Tester Checklist

- [ ] Tap the mic button, then tap the X in the top-right of the sheet — it closes without saving anything
- [ ] The X is visible while it says "Listening...", on the review screen, and on error screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)