### PR TITLE
fix(home): radial menu anchors to date cell center (#188)

### DIFF
--- a/lib/features/daily_journal/home_screen.dart
+++ b/lib/features/daily_journal/home_screen.dart
@@ -31,6 +31,12 @@ class _HomeScreenState extends State<HomeScreen> {
 
   /// Stable key per visible day cell so the radial menu can anchor to the
   /// tapped cell's center instead of the raw tap position (#188).
+  ///
+  /// INVARIANT: relies on `outsideDaysVisible: false` on the calendar.
+  /// table_calendar renders outside days before the custom builders only
+  /// when they are hidden; with visible outside days a selected/today
+  /// boundary date would build on BOTH adjacent month pages mid-swipe and
+  /// duplicate a GlobalKey (framework crash).
   final Map<String, GlobalKey> _dayCellKeys = {};
 
   GlobalKey _dayCellKey(DateTime day) =>
@@ -199,7 +205,9 @@ class _HomeScreenState extends State<HomeScreen> {
                             context,
                             selectedDay,
                             // Anchor to the cell center; fall back to the
-                            // tap position if the cell isn't laid out (#188).
+                            // tap position when the cell has no key/box —
+                            // e.g. outside days in week/two-week formats,
+                            // which skip the custom builders (#188).
                             anchor:
                                 _dayCellCenter(selectedDay) ??
                                 _lastTapGlobalPosition,

--- a/lib/features/daily_journal/home_screen.dart
+++ b/lib/features/daily_journal/home_screen.dart
@@ -29,6 +29,23 @@ class _HomeScreenState extends State<HomeScreen> {
   OverlayEntry? _radialMenuOverlay;
   Offset? _lastTapGlobalPosition;
 
+  /// Stable key per visible day cell so the radial menu can anchor to the
+  /// tapped cell's center instead of the raw tap position (#188).
+  final Map<String, GlobalKey> _dayCellKeys = {};
+
+  GlobalKey _dayCellKey(DateTime day) =>
+      _dayCellKeys.putIfAbsent(_dateFormat.format(day), GlobalKey.new);
+
+  /// Global center of the rendered cell for [day], or null if not laid out.
+  Offset? _dayCellCenter(DateTime day) {
+    final box =
+        _dayCellKeys[_dateFormat.format(day)]?.currentContext
+                ?.findRenderObject()
+            as RenderBox?;
+    if (box == null || !box.hasSize) return null;
+    return box.localToGlobal(box.size.center(Offset.zero));
+  }
+
   @override
   void initState() {
     super.initState();
@@ -181,7 +198,11 @@ class _HomeScreenState extends State<HomeScreen> {
                           _showRadialMenu(
                             context,
                             selectedDay,
-                            tapPosition: _lastTapGlobalPosition,
+                            // Anchor to the cell center; fall back to the
+                            // tap position if the cell isn't laid out (#188).
+                            anchor:
+                                _dayCellCenter(selectedDay) ??
+                                _lastTapGlobalPosition,
                           );
                         },
                         onFormatChanged: (format) {
@@ -200,37 +221,46 @@ class _HomeScreenState extends State<HomeScreen> {
                         },
                         calendarBuilders: CalendarBuilders(
                           defaultBuilder: (context, day, focusedDay) =>
-                              CompletionRingCell(
-                                day: day,
-                                categoryMarkers:
-                                    journalState
-                                        .monthCategoryMarkers[_dateFormat
-                                        .format(day)],
-                                activeCategories:
-                                    categoryState.activeCategories,
+                              KeyedSubtree(
+                                key: _dayCellKey(day),
+                                child: CompletionRingCell(
+                                  day: day,
+                                  categoryMarkers:
+                                      journalState
+                                          .monthCategoryMarkers[_dateFormat
+                                          .format(day)],
+                                  activeCategories:
+                                      categoryState.activeCategories,
+                                ),
                               ),
                           todayBuilder: (context, day, focusedDay) =>
-                              CompletionRingCell(
-                                day: day,
-                                categoryMarkers:
-                                    journalState
-                                        .monthCategoryMarkers[_dateFormat
-                                        .format(day)],
-                                activeCategories:
-                                    categoryState.activeCategories,
-                                isToday: true,
+                              KeyedSubtree(
+                                key: _dayCellKey(day),
+                                child: CompletionRingCell(
+                                  day: day,
+                                  categoryMarkers:
+                                      journalState
+                                          .monthCategoryMarkers[_dateFormat
+                                          .format(day)],
+                                  activeCategories:
+                                      categoryState.activeCategories,
+                                  isToday: true,
+                                ),
                               ),
                           selectedBuilder: (context, day, focusedDay) =>
-                              CompletionRingCell(
-                                day: day,
-                                categoryMarkers:
-                                    journalState
-                                        .monthCategoryMarkers[_dateFormat
-                                        .format(day)],
-                                activeCategories:
-                                    categoryState.activeCategories,
-                                isSelected: true,
-                                isToday: isSameDay(day, DateTime.now()),
+                              KeyedSubtree(
+                                key: _dayCellKey(day),
+                                child: CompletionRingCell(
+                                  day: day,
+                                  categoryMarkers:
+                                      journalState
+                                          .monthCategoryMarkers[_dateFormat
+                                          .format(day)],
+                                  activeCategories:
+                                      categoryState.activeCategories,
+                                  isSelected: true,
+                                  isToday: isSameDay(day, DateTime.now()),
+                                ),
                               ),
                         ),
                         headerStyle: HeaderStyle(
@@ -396,7 +426,7 @@ class _HomeScreenState extends State<HomeScreen> {
   void _showRadialMenu(
     BuildContext context,
     DateTime selectedDay, {
-    Offset? tapPosition,
+    Offset? anchor,
   }) {
     _dismissRadialMenu();
 
@@ -426,12 +456,12 @@ class _HomeScreenState extends State<HomeScreen> {
     const menuSize = 250.0;
     const menuPadding = 16.0;
 
-    // Fall back to screen center if no tap position
-    final effectiveTap =
-        tapPosition ?? Offset(screenSize.width / 2, screenSize.height / 2);
+    // Fall back to screen center if no anchor is available
+    final effectiveAnchor =
+        anchor ?? Offset(screenSize.width / 2, screenSize.height / 2);
 
     final menuOffset = clampMenuPosition(
-      tapPosition: effectiveTap,
+      tapPosition: effectiveAnchor,
       screenSize: screenSize,
       menuSize: menuSize,
       padding: menuPadding,

--- a/test/widgets/home_screen_radial_menu_test.dart
+++ b/test/widgets/home_screen_radial_menu_test.dart
@@ -424,16 +424,21 @@ void main() {
     testWidgets('menu centers on the tapped cell, not the tap position', (
       tester,
     ) async {
-      final today = DateTime.now();
-      final todayStr = dateFormat.format(today);
+      // Fixed mid-month day: the 15th is never in the first calendar row
+      // and exists in every month, so the assertion's discrimination power
+      // does not depend on the date the suite runs (review finding on
+      // DateTime.now()-based cells in clamp-adjacent columns).
+      final now = DateTime.now();
+      final fixedDay = DateTime(now.year, now.month, 15);
+      final dayStr = dateFormat.format(fixedDay);
 
       await tester.pumpApp(
         const HomeScreen(),
         journalState: JournalState(
           status: JournalStatus.loaded,
-          selectedDate: today,
+          selectedDate: fixedDay,
           monthCategoryMarkers: {
-            todayStr: {'positive': 1},
+            dayStr: {'positive': 1},
           },
         ),
         categoryState: CategoryState(
@@ -443,15 +448,16 @@ void main() {
       );
       await tester.pump(const Duration(seconds: 1));
 
-      // Locate today's cell and tap OFF-center, near its top-left corner.
+      // Locate the cell and tap OFF-center, near its top-left corner.
       final cellFinder = find
           .ancestor(
-            of: find.text('${today.day}').first,
+            of: find.text('15').first,
             matching: find.byType(CompletionRingCell),
           )
           .first;
       final cellRect = tester.getRect(cellFinder);
-      await tester.tapAt(cellRect.topLeft + const Offset(4, 4));
+      final tapPoint = cellRect.topLeft + const Offset(4, 4);
+      await tester.tapAt(tapPoint);
       await tester.pumpAndSettle();
 
       expect(find.byType(CategoryRadialMenu), findsOneWidget);
@@ -466,17 +472,30 @@ void main() {
         menuSize: 250,
         padding: 16,
       );
-      final menuRect = tester.getRect(
+      final buggyTopLeft = clampMenuPosition(
+        tapPosition: tapPoint,
+        screenSize: screenSize,
+        menuSize: 250,
+        padding: 16,
+      );
+      final positioned = tester.widget<Positioned>(
         find
             .ancestor(
               of: find.byType(CategoryRadialMenu),
-              matching: find.byType(SizedBox),
+              matching: find.byType(Positioned),
             )
             .first,
       );
 
-      expect(menuRect.left, closeTo(expectedTopLeft.dx, 1.0));
-      expect(menuRect.top, closeTo(expectedTopLeft.dy, 1.0));
+      expect(positioned.left, closeTo(expectedTopLeft.dx, 1.0));
+      expect(positioned.top, closeTo(expectedTopLeft.dy, 1.0));
+      // Guard the test's own discrimination power: the cell-center anchor
+      // must be distinguishable from the old tap-position anchor here.
+      expect(
+        (buggyTopLeft - expectedTopLeft).distance,
+        greaterThan(2.0),
+        reason: 'corner tap and cell center must clamp to different anchors',
+      );
     });
   });
 }

--- a/test/widgets/home_screen_radial_menu_test.dart
+++ b/test/widgets/home_screen_radial_menu_test.dart
@@ -7,8 +7,10 @@ import 'package:mocktail/mocktail.dart';
 import 'package:dytty/data/models/category_config.dart';
 import 'package:dytty/data/models/category_entry.dart';
 import 'package:dytty/features/daily_journal/bloc/journal_bloc.dart';
+import 'package:dytty/core/utils/menu_position_utils.dart';
 import 'package:dytty/features/daily_journal/home_screen.dart';
 import 'package:dytty/features/daily_journal/widgets/category_radial_menu.dart';
+import 'package:dytty/features/daily_journal/widgets/completion_ring_cell.dart';
 import 'package:dytty/features/settings/cubit/category_cubit.dart';
 
 import '../helpers/pump_app.dart';
@@ -415,6 +417,66 @@ void main() {
 
       // Mic button in center of radial menu
       expect(find.bySemanticsLabel('Start voice call'), findsOneWidget);
+    });
+  });
+
+  group('Radial menu anchors to date cell center (#188)', () {
+    testWidgets('menu centers on the tapped cell, not the tap position', (
+      tester,
+    ) async {
+      final today = DateTime.now();
+      final todayStr = dateFormat.format(today);
+
+      await tester.pumpApp(
+        const HomeScreen(),
+        journalState: JournalState(
+          status: JournalStatus.loaded,
+          selectedDate: today,
+          monthCategoryMarkers: {
+            todayStr: {'positive': 1},
+          },
+        ),
+        categoryState: CategoryState(
+          categories: CategoryConfig.defaults,
+          loaded: true,
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      // Locate today's cell and tap OFF-center, near its top-left corner.
+      final cellFinder = find
+          .ancestor(
+            of: find.text('${today.day}').first,
+            matching: find.byType(CompletionRingCell),
+          )
+          .first;
+      final cellRect = tester.getRect(cellFinder);
+      await tester.tapAt(cellRect.topLeft + const Offset(4, 4));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CategoryRadialMenu), findsOneWidget);
+
+      // The menu must anchor to the CELL CENTER (clamped to screen), not
+      // the raw tap position near the corner.
+      final screenSize =
+          tester.view.physicalSize / tester.view.devicePixelRatio;
+      final expectedTopLeft = clampMenuPosition(
+        tapPosition: cellRect.center,
+        screenSize: screenSize,
+        menuSize: 250,
+        padding: 16,
+      );
+      final menuRect = tester.getRect(
+        find
+            .ancestor(
+              of: find.byType(CategoryRadialMenu),
+              matching: find.byType(SizedBox),
+            )
+            .first,
+      );
+
+      expect(menuRect.left, closeTo(expectedTopLeft.dx, 1.0));
+      expect(menuRect.top, closeTo(expectedTopLeft.dy, 1.0));
     });
   });
 }


### PR DESCRIPTION
## Summary

The radial menu opened at the exact tap coordinates (#175 behavior, needed for tap-and-hold which was removed in #56). It now anchors to the center of the tapped date cell — cleaner and predictable.

Fixes #188

## Key Decisions

- Stable `GlobalKey` per visible day cell (lazy map + `KeyedSubtree` in the calendar cell builders). The cell's `RenderBox` center is resolved synchronously in `onDaySelected` — no post-frame timing races.
- `clampMenuPosition` reused unchanged (it already centers the menu box on whatever anchor it gets); the `Listener` tap capture remains as fallback.
- Edge/corner clamping behavior intentionally untouched — #190 (algorithmic spacing + edge-aware bubbles) reworks that separately.

## Test Plan

- [x] New widget test: taps a cell near its corner, asserts the menu centers on the cell center, not the tap point (failed before fix with a 37px delta)
- [x] All existing radial positioning + clamping tests still green
- [x] Full suite green, `flutter analyze` clean (7 pre-existing infos)
- [x] Device check on Pixel 9a (see screenshot)

## Tester Checklist

- [ ] Tap different calendar dates, including near screen edges — the category menu always blooms from the date you tapped

🤖 Generated with [Claude Code](https://claude.com/claude-code)