### PR TITLE
chore: complete state-management batch — batch writes, E2E regression suite, web delete fix (#110, #162, #205)

### DIFF
--- a/.maestro/journal/radial-menu-position-flow.yaml
+++ b/.maestro/journal/radial-menu-position-flow.yaml
@@ -11,6 +11,7 @@ tags:
 # Test 1: Tap mid-calendar date — menu should open near it
 - tapOn:
     point: "7%,35%"
+    retryTapIfNoChange: false
 - extendedWaitUntil:
     visible: "Start voice call"
     timeout: 5000
@@ -26,7 +27,8 @@ tags:
 
 # Test 2: Tap top-row date — menu should clamp within bounds
 - tapOn:
-    point: "37%,26%"
+    point: "37%,30%"
+    retryTapIfNoChange: false
 - extendedWaitUntil:
     visible: "Start voice call"
     timeout: 5000
@@ -43,6 +45,7 @@ tags:
 # Test 3: Tap bottom-row date
 - tapOn:
     point: "7%,44%"
+    retryTapIfNoChange: false
 - extendedWaitUntil:
     visible: "Start voice call"
     timeout: 5000

--- a/.maestro/state/delete-last-entry-ring-unfills.yaml
+++ b/.maestro/state/delete-last-entry-ring-unfills.yaml
@@ -1,0 +1,47 @@
+appId: com.dytty.dytty
+name: "State: deleting the last entry unfills the ring and restores the nudge"
+tags:
+  - state
+  - regression
+---
+# Regression test for #162: removing a date's only entry must clear its
+# marker — ring empties, progress drops, nudge banner returns.
+
+- runFlow: "../helpers/login.yaml"
+
+- assertVisible: "Progress 0 of 5"
+
+# Add a single entry today
+- tapOn: "Today button"
+- waitForAnimationToEnd
+- tapOn: "Add Positive Things entry"
+- waitForAnimationToEnd
+- tapOn: "What good things happened today.*"
+- eraseText
+- inputText: "Entry to delete"
+- tapOn: "Save"
+- waitForAnimationToEnd:
+    timeout: 5000
+- assertVisible: ".*Entry to delete.*"
+
+- back
+- waitForAnimationToEnd:
+    timeout: 5000
+- assertVisible: "Progress 1 of 5.*"
+
+# Delete the entry
+- tapOn: "Today button"
+- waitForAnimationToEnd
+- tapOn: "Delete entry"
+- waitForAnimationToEnd:
+    timeout: 5000
+
+# Back home: ring unfilled, nudge back (#162 checklist: date key
+# removed from markers)
+- back
+- waitForAnimationToEnd:
+    timeout: 5000
+- assertVisible: "Progress 0 of 5"
+- assertVisible: "You haven't journaled today"
+
+- takeScreenshot: ".maestro/screenshots/latest/state/162-delete-ring-unfills"

--- a/.maestro/state/delete-last-entry-ring-unfills.yaml
+++ b/.maestro/state/delete-last-entry-ring-unfills.yaml
@@ -37,11 +37,12 @@ tags:
     timeout: 5000
 
 # Back home: ring unfilled, nudge back (#162 checklist: date key
-# removed from markers)
+# removed from markers). ".*" suffixes: streak text may follow the
+# progress label, and the nudge apostrophe is typographic.
 - back
 - waitForAnimationToEnd:
     timeout: 5000
-- assertVisible: "Progress 0 of 5"
-- assertVisible: "You haven't journaled today"
+- assertVisible: "Progress 0 of 5.*"
+- assertVisible: "You haven.*journaled today.*"
 
 - takeScreenshot: ".maestro/screenshots/latest/state/162-delete-ring-unfills"

--- a/.maestro/state/past-date-ring-fills.yaml
+++ b/.maestro/state/past-date-ring-fills.yaml
@@ -1,0 +1,40 @@
+appId: com.dytty.dytty
+name: "State: adding entry on a past date fills that date's ring, not today's"
+tags:
+  - state
+  - regression
+---
+# Regression test for #162 (state-management E2E): an entry added on a
+# past date must mark THAT date — today's dashboard stays untouched.
+
+- runFlow: "../helpers/login.yaml"
+
+# Clean slate
+- assertVisible: "Progress 0 of 5"
+
+# Open today's journal and step back one day
+- tapOn: "Today button"
+- waitForAnimationToEnd
+- tapOn: "Previous day"
+- waitForAnimationToEnd
+
+# Add an entry on the past date
+- tapOn: "Add Positive Things entry"
+- waitForAnimationToEnd
+- tapOn: "What good things happened today.*"
+- eraseText
+- inputText: "Past date ring entry"
+- tapOn: "Save"
+- waitForAnimationToEnd:
+    timeout: 5000
+- assertVisible: ".*Past date ring entry.*"
+
+# Back to home: today's progress must STILL be 0 of 5 — the entry
+# belongs to yesterday, not today.
+- back
+- waitForAnimationToEnd:
+    timeout: 5000
+- assertVisible: "Progress 0 of 5"
+- assertVisible: "You haven't journaled today"
+
+- takeScreenshot: ".maestro/screenshots/latest/state/162-past-date-ring"

--- a/.maestro/state/past-date-ring-fills.yaml
+++ b/.maestro/state/past-date-ring-fills.yaml
@@ -30,11 +30,13 @@ tags:
 - assertVisible: ".*Past date ring entry.*"
 
 # Back to home: today's progress must STILL be 0 of 5 — the entry
-# belongs to yesterday, not today.
+# belongs to yesterday, not today. (".*" — yesterday's entry bumps the
+# streak, so the label gains a ", streak 1 day" suffix. Apostrophe in
+# the nudge is typographic; match with ".*" like sibling flows.)
 - back
 - waitForAnimationToEnd:
     timeout: 5000
-- assertVisible: "Progress 0 of 5"
-- assertVisible: "You haven't journaled today"
+- assertVisible: "Progress 0 of 5.*"
+- assertVisible: "You haven.*journaled today.*"
 
 - takeScreenshot: ".maestro/screenshots/latest/state/162-past-date-ring"

--- a/e2e/state-regression.spec.ts
+++ b/e2e/state-regression.spec.ts
@@ -79,13 +79,10 @@ test.describe('State regression: cross-date navigation and undo', () => {
     await page.getByRole('button', { name: 'Previous day' }).click();
     await addEntry(page, 'Positive Things', 'Undo target entry');
 
-    // Delete it, then Undo from the snackbar.
+    // Delete it, then Undo from the snackbar. (No confirm dialog exists —
+    // delete is optimistic with an Undo snackbar; if a dialog ever
+    // appears, the next assertion fails loudly instead of being skipped.)
     await page.getByRole('button', { name: 'Delete entry' }).first().click();
-    // Confirm dialog if present; otherwise the snackbar appears directly.
-    const confirmDelete = page.getByRole('button', { name: 'Delete' });
-    if (await confirmDelete.isVisible({ timeout: 2_000 }).catch(() => false)) {
-      await confirmDelete.click();
-    }
     await expect(
       page.getByLabel('Journal entry: Undo target entry'),
     ).not.toBeVisible({ timeout: 10_000 });

--- a/e2e/state-regression.spec.ts
+++ b/e2e/state-regression.spec.ts
@@ -1,0 +1,146 @@
+import { test, expect, Page } from '@playwright/test';
+import {
+  waitForFlutterReady,
+  clickByLabel,
+  signInAnonymously,
+  clearEmulatorAuth,
+  clearEmulatorFirestore,
+} from './helpers';
+
+/**
+ * State-management E2E regression suite (#162).
+ *
+ * Covers the UI-wiring paths bloc tests cannot see:
+ * - entries surviving cross-date navigation (#153 family)
+ * - delete + Undo restoring on the correct date
+ * - progress card staying today-sourced when a past date is selected
+ *   (#154 contract — the card NEVER switches to the selected date)
+ *
+ * "Radial menu checkmarks" from the issue checklist is covered at widget
+ * level (home_screen_radial_menu_test: badges-from-state); its E2E needs
+ * accessible labels on CircularMenuItem bubbles, deferred to the #190
+ * menu rework.
+ */
+
+/** Adds an entry in a category on the daily journal screen. */
+async function addEntry(page: Page, categoryName: string, text: string) {
+  await page.getByRole('button', { name: `Add ${categoryName} entry` }).click();
+  const textField = page.getByRole('textbox');
+  await expect(textField).toBeVisible({ timeout: 10_000 });
+  await textField.fill(text);
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(page.getByLabel(`Journal entry: ${text}`)).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+test.describe('State regression: cross-date navigation and undo', () => {
+  test.beforeEach(async ({ page }) => {
+    await clearEmulatorAuth();
+    await clearEmulatorFirestore();
+    await page.goto('/');
+    await waitForFlutterReady(page);
+    await signInAnonymously(page);
+  });
+
+  test('entry added on a past date survives A -> B -> A navigation', async ({
+    page,
+  }) => {
+    // Go to today's journal, then step back one day (date A = yesterday).
+    await clickByLabel(page, 'Today button');
+    await expect(page.getByLabel('Positive Things category')).toBeVisible({
+      timeout: 10_000,
+    });
+    await page.getByRole('button', { name: 'Previous day' }).click();
+    await addEntry(page, 'Positive Things', 'Yesterday entry A');
+
+    // Navigate to date B (two days ago), then back to A.
+    await page.getByRole('button', { name: 'Previous day' }).click();
+    await expect(
+      page.getByLabel('Journal entry: Yesterday entry A'),
+    ).not.toBeVisible({ timeout: 10_000 });
+    await page.getByRole('button', { name: 'Next day' }).click();
+
+    // Entry must still be on date A.
+    await expect(
+      page.getByLabel('Journal entry: Yesterday entry A'),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('delete then Undo restores the entry on the correct date', async ({
+    page,
+  }) => {
+    // Add an entry on yesterday (a non-today date so a wrong-date restore
+    // would be visible as a failure).
+    await clickByLabel(page, 'Today button');
+    await expect(page.getByLabel('Positive Things category')).toBeVisible({
+      timeout: 10_000,
+    });
+    await page.getByRole('button', { name: 'Previous day' }).click();
+    await addEntry(page, 'Positive Things', 'Undo target entry');
+
+    // Delete it, then Undo from the snackbar.
+    await page.getByRole('button', { name: 'Delete entry' }).first().click();
+    // Confirm dialog if present; otherwise the snackbar appears directly.
+    const confirmDelete = page.getByRole('button', { name: 'Delete' });
+    if (await confirmDelete.isVisible({ timeout: 2_000 }).catch(() => false)) {
+      await confirmDelete.click();
+    }
+    await expect(
+      page.getByLabel('Journal entry: Undo target entry'),
+    ).not.toBeVisible({ timeout: 10_000 });
+    await page.getByRole('button', { name: 'Undo' }).click();
+
+    // Restored on this (past) date...
+    await expect(
+      page.getByLabel('Journal entry: Undo target entry'),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // ...and NOT on today: navigate to today and assert absence.
+    await page.getByRole('button', { name: 'Next day' }).click();
+    await expect(
+      page.getByLabel('Journal entry: Undo target entry'),
+    ).not.toBeVisible({ timeout: 10_000 });
+
+    // Round-trip back to the past date — still there (persisted, not
+    // just optimistic state).
+    await page.getByRole('button', { name: 'Previous day' }).click();
+    await expect(
+      page.getByLabel('Journal entry: Undo target entry'),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('progress card stays today-sourced when a past date is selected (#154)', async ({
+    page,
+  }) => {
+    // Add one entry today so today's progress is 1 of 5.
+    await clickByLabel(page, 'Today button');
+    await expect(page.getByLabel('Positive Things category')).toBeVisible({
+      timeout: 10_000,
+    });
+    await addEntry(page, 'Positive Things', 'Today progress source');
+
+    // Select a past date via the journal chevron (same SelectDate event a
+    // calendar tap dispatches; day cells aren't actionable on web and the
+    // radial overlay isn't needed for this contract).
+    await page.getByRole('button', { name: 'Previous day' }).click();
+    await expect(
+      page.getByLabel('Journal entry: Today progress source'),
+    ).not.toBeVisible({ timeout: 10_000 });
+
+    // Back to home — selectedDate is still yesterday (HomeScreen is not
+    // re-mounted on pop, so initState's SelectDate(today) does not fire).
+    await page.goBack();
+    await expect(page.getByRole('button', { name: 'Today button' })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // The dashboard must show TODAY's progress (1 of 5), not the selected
+    // past date's (0 entries) — pre-#154 code showed 'Progress 0 of 5'
+    // here. The card title isn't asserted: the Semantics wrapper means
+    // inner text isn't exposed to the DOM; the label carries the contract.
+    await expect(page.getByLabel('Progress 1 of 5')).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+});

--- a/lib/data/repositories/journal_repository.dart
+++ b/lib/data/repositories/journal_repository.dart
@@ -157,14 +157,20 @@ class JournalRepository {
     await _categoryEntries(date).doc(entryId).update({'isReviewed': true});
   }
 
+  /// Firestore's WriteBatch operation limit.
+  static const _maxBatchOps = 500;
+
   /// Marks many entries reviewed using batched writes (#110).
-  /// Chunked at 500 operations — the Firestore WriteBatch limit.
+  ///
+  /// Atomic per chunk of [_maxBatchOps] only: beyond 500 refs a later
+  /// chunk can fail after earlier ones committed. Review sessions are far
+  /// below that today; revisit if they ever approach the limit.
   Future<void> markEntriesReviewed(
     List<({String date, String entryId})> refs,
   ) async {
-    for (var i = 0; i < refs.length; i += 500) {
+    for (var i = 0; i < refs.length; i += _maxBatchOps) {
       final batch = _firestore.batch();
-      for (final ref in refs.skip(i).take(500)) {
+      for (final ref in refs.skip(i).take(_maxBatchOps)) {
         batch.update(_categoryEntries(ref.date).doc(ref.entryId), {
           'isReviewed': true,
         });

--- a/lib/data/repositories/journal_repository.dart
+++ b/lib/data/repositories/journal_repository.dart
@@ -157,6 +157,22 @@ class JournalRepository {
     await _categoryEntries(date).doc(entryId).update({'isReviewed': true});
   }
 
+  /// Marks many entries reviewed using batched writes (#110).
+  /// Chunked at 500 operations — the Firestore WriteBatch limit.
+  Future<void> markEntriesReviewed(
+    List<({String date, String entryId})> refs,
+  ) async {
+    for (var i = 0; i < refs.length; i += 500) {
+      final batch = _firestore.batch();
+      for (final ref in refs.skip(i).take(500)) {
+        batch.update(_categoryEntries(ref.date).doc(ref.entryId), {
+          'isReviewed': true,
+        });
+      }
+      await batch.commit();
+    }
+  }
+
   /// Saves or updates a review summary.
   /// Upserts by categoryId + weekStart — updates if exists, creates if not.
   Future<void> saveReviewSummary(ReviewSummary summary) async {

--- a/lib/features/category_detail/bloc/category_detail_bloc.dart
+++ b/lib/features/category_detail/bloc/category_detail_bloc.dart
@@ -457,19 +457,18 @@ class CategoryDetailBloc
 
     emit(state.copyWith(recentEntries: updatedGroups));
 
-    // Persist to Firestore
-    for (final ref in event.entries) {
-      try {
-        await _repository.markEntryReviewed(ref.date, ref.entryId);
-      } catch (e) {
-        emit(
-          state.copyWith(
-            recentEntries: previousGroups,
-            error: 'Failed to mark entry as reviewed: $e',
-          ),
-        );
-        return;
-      }
+    // Persist to Firestore in a single batch write (#110)
+    try {
+      await _repository.markEntriesReviewed([
+        for (final ref in event.entries) (date: ref.date, entryId: ref.entryId),
+      ]);
+    } catch (e) {
+      emit(
+        state.copyWith(
+          recentEntries: previousGroups,
+          error: 'Failed to mark entries as reviewed: $e',
+        ),
+      );
     }
   }
 

--- a/lib/features/daily_journal/bloc/journal_bloc.dart
+++ b/lib/features/daily_journal/bloc/journal_bloc.dart
@@ -223,6 +223,12 @@ class JournalBloc extends Bloc<JournalEvent, JournalState> {
   /// Active subscription to the selected date's entries.
   StreamSubscription<List<CategoryEntry>>? _entriesSubscription;
 
+  /// Tombstones for optimistically deleted entries: a snapshot generated
+  /// before the delete can arrive after it and resurrect the entry — and
+  /// on web the corrective post-delete emit is unreliable (#205).
+  /// Cleared on SelectDate (fresh subscription = fresh server truth).
+  final Set<String> _pendingDeletes = {};
+
   /// Exposes the repository for sibling blocs that share the same data source.
   JournalRepository get repository => _repository;
 
@@ -287,8 +293,10 @@ class JournalBloc extends Bloc<JournalEvent, JournalState> {
       state.copyWith(selectedDate: event.date, status: JournalStatus.loading),
     );
 
-    // Cancel previous date's subscription
+    // Cancel previous date's subscription; fresh subscription supersedes
+    // any pending delete tombstones.
     await _entriesSubscription?.cancel();
+    _pendingDeletes.clear();
 
     final dateString = JournalState._dateFormat.format(event.date);
 
@@ -506,6 +514,7 @@ class JournalBloc extends Bloc<JournalEvent, JournalState> {
         state.selectedDateString,
         event.entryId,
       );
+      _pendingDeletes.add(event.entryId);
       // Entries are updated via the stream subscription (_EntriesUpdated).
       // Optimistically update markers only.
       final currentMarkers = _cloneMarkers(state.monthCategoryMarkers);
@@ -635,10 +644,14 @@ class JournalBloc extends Bloc<JournalEvent, JournalState> {
         : JournalStatus.loaded;
     // Preserve any pending load error — the cache-first stream otherwise
     // masks marker/streak failures and the user never sees feedback (#170).
+    // Filter tombstoned deletes: a pre-delete snapshot arriving late must
+    // not resurrect an optimistically removed entry (#205).
     emit(
       state.copyWith(
         status: status,
-        entries: event.entries,
+        entries: event.entries
+            .where((e) => !_pendingDeletes.contains(e.id))
+            .toList(),
         error: state.error,
       ),
     );

--- a/lib/features/daily_journal/bloc/journal_bloc.dart
+++ b/lib/features/daily_journal/bloc/journal_bloc.dart
@@ -546,6 +546,10 @@ class JournalBloc extends Bloc<JournalEvent, JournalState> {
       emit(
         state.copyWith(
           status: JournalStatus.loaded,
+          // Optimistic removal — the web SDK's snapshots emit after a
+          // local delete is unreliable (#205), same reason adds are
+          // optimistic (#44). The stream reconciles later if needed.
+          entries: state.entries.where((e) => e.id != event.entryId).toList(),
           monthCategoryMarkers: currentMarkers,
           todayCategoryCounts: todayCounts,
         ),

--- a/scripts/device-test.sh
+++ b/scripts/device-test.sh
@@ -61,6 +61,13 @@ fi
 if [[ -z "${DEVICE_TEST_EMAIL:-}" && -f "$PROJECT_DIR/.env" ]]; then
   DEVICE_TEST_EMAIL=$(grep DEVICE_TEST_EMAIL "$PROJECT_DIR/.env" | cut -d= -f2 || true)
 fi
+# UID powers device-cleanup.sh's direct path — the auth:export email
+# lookup fallback does not work (#206), so cleanup silently no-ops
+# between flows and every flow after the first inherits stale data.
+if [[ -z "${DEVICE_TEST_UID:-}" && -f "$PROJECT_DIR/.env" ]]; then
+  DEVICE_TEST_UID=$(grep DEVICE_TEST_UID "$PROJECT_DIR/.env" | cut -d= -f2 || true)
+  export DEVICE_TEST_UID
+fi
 if [[ -z "${DEVICE_TEST_EMAIL:-}" ]]; then
   echo "ERROR: DEVICE_TEST_EMAIL not set. Add to .env or export it."
   exit 1
@@ -170,6 +177,10 @@ echo ""
 MAESTRO_BASE="maestro test"
 MAESTRO_BASE="$MAESTRO_BASE --debug-output $SCREENSHOT_DIR"
 MAESTRO_BASE="$MAESTRO_BASE --format junit"
+# Maestro flows cannot read plain shell exports: ${DEVICE_TEST_EMAIL} in
+# login-device.yaml only resolves from -e params. Without this the account
+# tap never matches and login hangs (#206, regression from fa97007).
+MAESTRO_BASE="$MAESTRO_BASE -e DEVICE_TEST_EMAIL=$DEVICE_TEST_EMAIL"
 
 if [[ -n "$TAGS" ]]; then
   MAESTRO_BASE="$MAESTRO_BASE --include-tags=$TAGS"

--- a/scripts/device-test.sh
+++ b/scripts/device-test.sh
@@ -58,14 +58,15 @@ if [[ -d "$LOCALAPPDATA/Android/Sdk/platform-tools" ]]; then
 fi
 
 # ── Load test email from .env if not set ──────────────
+# Anchored grep + -f2-: skip commented lines, keep values containing '='.
 if [[ -z "${DEVICE_TEST_EMAIL:-}" && -f "$PROJECT_DIR/.env" ]]; then
-  DEVICE_TEST_EMAIL=$(grep DEVICE_TEST_EMAIL "$PROJECT_DIR/.env" | cut -d= -f2 || true)
+  DEVICE_TEST_EMAIL=$(grep '^DEVICE_TEST_EMAIL=' "$PROJECT_DIR/.env" | cut -d= -f2- || true)
 fi
 # UID powers device-cleanup.sh's direct path — the auth:export email
 # lookup fallback does not work (#206), so cleanup silently no-ops
 # between flows and every flow after the first inherits stale data.
 if [[ -z "${DEVICE_TEST_UID:-}" && -f "$PROJECT_DIR/.env" ]]; then
-  DEVICE_TEST_UID=$(grep DEVICE_TEST_UID "$PROJECT_DIR/.env" | cut -d= -f2 || true)
+  DEVICE_TEST_UID=$(grep '^DEVICE_TEST_UID=' "$PROJECT_DIR/.env" | cut -d= -f2- || true)
   export DEVICE_TEST_UID
 fi
 if [[ -z "${DEVICE_TEST_EMAIL:-}" ]]; then
@@ -174,16 +175,18 @@ echo "=== Running Maestro flows on device ==="
 echo "  Screenshots: $SCREENSHOT_DIR"
 echo ""
 
-MAESTRO_BASE="maestro test"
-MAESTRO_BASE="$MAESTRO_BASE --debug-output $SCREENSHOT_DIR"
-MAESTRO_BASE="$MAESTRO_BASE --format junit"
+# Array form: values stay single words under expansion (quoting review
+# finding — the email is the first variable-bearing argument here).
 # Maestro flows cannot read plain shell exports: ${DEVICE_TEST_EMAIL} in
 # login-device.yaml only resolves from -e params. Without this the account
 # tap never matches and login hangs (#206, regression from fa97007).
-MAESTRO_BASE="$MAESTRO_BASE -e DEVICE_TEST_EMAIL=$DEVICE_TEST_EMAIL"
+MAESTRO_ARGS=(maestro test
+  --debug-output "$SCREENSHOT_DIR"
+  --format junit
+  -e "DEVICE_TEST_EMAIL=$DEVICE_TEST_EMAIL")
 
 if [[ -n "$TAGS" ]]; then
-  MAESTRO_BASE="$MAESTRO_BASE --include-tags=$TAGS"
+  MAESTRO_ARGS+=("--include-tags=$TAGS")
 fi
 
 FLOW_RESULTS_DIR="$SCREENSHOT_DIR/flow-results"
@@ -208,7 +211,7 @@ for dir in "$MAESTRO_DIR"/*/; do
     if [[ "$SKIP_CLEANUP" == false ]] && command -v firebase &>/dev/null; then
       bash "$SCRIPT_DIR/device-cleanup.sh" 2>/dev/null || true
     fi
-    if ! $MAESTRO_BASE --output "$FLOW_RESULTS_DIR/$FLOW_INDEX.xml" "$flow" 2>&1; then
+    if ! "${MAESTRO_ARGS[@]}" --output "$FLOW_RESULTS_DIR/$FLOW_INDEX.xml" "$flow" 2>&1; then
       TEST_FAILED=true
     fi
     FLOW_INDEX=$((FLOW_INDEX + 1))

--- a/test/data/repositories/journal_repository_test.dart
+++ b/test/data/repositories/journal_repository_test.dart
@@ -447,6 +447,26 @@ void main() {
       test('no-op on empty list', () async {
         await repository.markEntriesReviewed(const []);
       });
+
+      test('handles more refs than one batch chunk (501)', () async {
+        // Exercises the chunk-boundary arithmetic; fake_cloud_firestore
+        // does not enforce the 500-op limit itself.
+        final refs = <({String date, String entryId})>[];
+        for (var i = 0; i < 501; i++) {
+          final entry = await repository.addCategoryEntry(
+            '2026-03-01',
+            'positive',
+            'bulk $i',
+          );
+          refs.add((date: '2026-03-01', entryId: entry.id));
+        }
+
+        await repository.markEntriesReviewed(refs);
+
+        final entries = await repository.getCategoryEntries('2026-03-01');
+        expect(entries.length, 501);
+        expect(entries.every((e) => e.isReviewed), true);
+      });
     });
 
     group('markEntryReviewed', () {

--- a/test/data/repositories/journal_repository_test.dart
+++ b/test/data/repositories/journal_repository_test.dart
@@ -393,6 +393,62 @@ void main() {
       });
     });
 
+    group('markEntriesReviewed (batch, #110)', () {
+      test('marks all referenced entries reviewed across dates', () async {
+        final a = await repository.addCategoryEntry(
+          '2026-03-01',
+          'positive',
+          'x',
+        );
+        final b = await repository.addCategoryEntry(
+          '2026-03-01',
+          'gratitude',
+          'y',
+        );
+        final c = await repository.addCategoryEntry(
+          '2026-03-02',
+          'positive',
+          'z',
+        );
+
+        await repository.markEntriesReviewed([
+          (date: '2026-03-01', entryId: a.id),
+          (date: '2026-03-01', entryId: b.id),
+          (date: '2026-03-02', entryId: c.id),
+        ]);
+
+        final day1 = await repository.getCategoryEntries('2026-03-01');
+        final day2 = await repository.getCategoryEntries('2026-03-02');
+        expect(day1.firstWhere((e) => e.id == a.id).isReviewed, true);
+        expect(day1.firstWhere((e) => e.id == b.id).isReviewed, true);
+        expect(day2.firstWhere((e) => e.id == c.id).isReviewed, true);
+      });
+
+      test('leaves unreferenced entries untouched', () async {
+        final a = await repository.addCategoryEntry(
+          '2026-03-01',
+          'positive',
+          'x',
+        );
+        final other = await repository.addCategoryEntry(
+          '2026-03-01',
+          'gratitude',
+          'y',
+        );
+
+        await repository.markEntriesReviewed([
+          (date: '2026-03-01', entryId: a.id),
+        ]);
+
+        final day = await repository.getCategoryEntries('2026-03-01');
+        expect(day.firstWhere((e) => e.id == other.id).isReviewed, false);
+      });
+
+      test('no-op on empty list', () async {
+        await repository.markEntriesReviewed(const []);
+      });
+    });
+
     group('markEntryReviewed', () {
       test('sets isReviewed to true on an entry', () async {
         final entry = await repository.addCategoryEntry(

--- a/test/features/category_detail/bloc/category_detail_bloc_test.dart
+++ b/test/features/category_detail/bloc/category_detail_bloc_test.dart
@@ -478,11 +478,10 @@ void main() {
           true,
         ),
         // Firestore persist fails (no doc seeded), error emitted
-        // Note: second entry error is deduplicated by Equatable (same message)
         isA<CategoryDetailState>().having(
           (s) => s.error,
           'error',
-          contains('Failed to mark entry as reviewed'),
+          contains('Failed to mark entries as reviewed'),
         ),
       ],
     );
@@ -577,6 +576,7 @@ void main() {
     });
 
     setUpAll(() {
+      registerFallbackValue(const <({String date, String entryId})>[]);
       registerFallbackValue(
         ReviewSummary(
           id: '',
@@ -649,11 +649,74 @@ void main() {
     );
 
     blocTest<CategoryDetailBloc, CategoryDetailState>(
+      'MarkEntriesReviewed persists all refs via one batch call (#110)',
+      build: () => CategoryDetailBloc(repository: mockRepo, clock: fixedClock),
+      setUp: () {
+        when(
+          () => mockRepo.markEntriesReviewed(any()),
+        ).thenAnswer((_) async {});
+      },
+      seed: () => CategoryDetailState(
+        status: CategoryDetailStatus.loaded,
+        categoryId: 'positive',
+        recentEntries: [
+          DateGroup(
+            date: '2026-03-18',
+            displayDate: 'Today',
+            entries: [
+              CategoryEntry(
+                id: 'e1',
+                categoryId: 'positive',
+                text: 'Entry 1',
+                createdAt: DateTime(2026, 3, 18),
+                isReviewed: false,
+              ),
+            ],
+          ),
+          DateGroup(
+            date: '2026-03-17',
+            displayDate: 'Yesterday',
+            entries: [
+              CategoryEntry(
+                id: 'e2',
+                categoryId: 'positive',
+                text: 'Entry 2',
+                createdAt: DateTime(2026, 3, 17),
+                isReviewed: false,
+              ),
+            ],
+          ),
+        ],
+        hasRecentEntries: true,
+      ),
+      act: (bloc) => bloc.add(
+        const MarkEntriesReviewed(
+          entries: [
+            EntryReference(date: '2026-03-18', entryId: 'e1'),
+            EntryReference(date: '2026-03-17', entryId: 'e2'),
+          ],
+        ),
+      ),
+      verify: (bloc) {
+        final captured =
+            verify(
+                  () => mockRepo.markEntriesReviewed(captureAny()),
+                ).captured.single
+                as List<({String date, String entryId})>;
+        expect(captured, [
+          (date: '2026-03-18', entryId: 'e1'),
+          (date: '2026-03-17', entryId: 'e2'),
+        ]);
+        verifyNever(() => mockRepo.markEntryReviewed(any(), any()));
+      },
+    );
+
+    blocTest<CategoryDetailBloc, CategoryDetailState>(
       'MarkEntriesReviewed emits error when repo throws',
       build: () => CategoryDetailBloc(repository: mockRepo, clock: fixedClock),
       setUp: () {
         when(
-          () => mockRepo.markEntryReviewed(any(), any()),
+          () => mockRepo.markEntriesReviewed(any()),
         ).thenThrow(Exception('network failure'));
       },
       seed: () => CategoryDetailState(
@@ -700,7 +763,7 @@ void main() {
             .having(
               (s) => s.error,
               'error contains message',
-              contains('Failed to mark entry as reviewed'),
+              contains('Failed to mark entries as reviewed'),
             ),
       ],
     );

--- a/test/features/daily_journal/journal_bloc_test.dart
+++ b/test/features/daily_journal/journal_bloc_test.dart
@@ -1158,6 +1158,72 @@ void main() {
         expect(bloc.state.status, JournalStatus.loaded);
       },
     );
+
+    blocTest<JournalBloc, JournalState>(
+      'a stale stream emit cannot resurrect a deleted entry',
+      setUp: () {
+        when(
+          () => mockRepository.deleteCategoryEntry(any(), any()),
+        ).thenAnswer((_) async {});
+        when(() => mockRepository.getStreakData()).thenAnswer(
+          (_) async => const StreakData(
+            currentStreak: 0,
+            longestStreak: 0,
+            lastJournalDate: null,
+          ),
+        );
+        when(
+          () => mockRepository.getMonthCategoryMarkers(any(), any()),
+        ).thenAnswer((_) async => {});
+      },
+      build: () => JournalBloc(repository: mockRepository),
+      seed: () => JournalState(
+        status: JournalStatus.loaded,
+        selectedDate: DateTime(2026, 3, 1),
+      ),
+      act: (bloc) async {
+        // Subscribe via SelectDate with a controllable stream, then emit a
+        // pre-delete snapshot AFTER the delete — the web SDK can deliver
+        // exactly this ordering (#205).
+        final controller = StreamController<List<CategoryEntry>>();
+        when(
+          () => mockRepository.watchCategoryEntries(any()),
+        ).thenAnswer((_) => controller.stream);
+
+        final e1 = CategoryEntry(
+          id: 'e1',
+          categoryId: 'positive',
+          text: 'doomed',
+          createdAt: DateTime(2026, 3, 1),
+        );
+        final e2 = CategoryEntry(
+          id: 'e2',
+          categoryId: 'gratitude',
+          text: 'survivor',
+          createdAt: DateTime(2026, 3, 1),
+        );
+
+        bloc.add(SelectDate(DateTime(2026, 3, 1)));
+        await Future.delayed(const Duration(milliseconds: 100));
+        controller.add([e1, e2]);
+        await Future.delayed(const Duration(milliseconds: 100));
+
+        bloc.add(const DeleteEntry('e1'));
+        await Future.delayed(const Duration(milliseconds: 100));
+
+        // Stale snapshot generated before the delete arrives late.
+        controller.add([e1, e2]);
+        await Future.delayed(const Duration(milliseconds: 100));
+        await controller.close();
+      },
+      verify: (bloc) {
+        expect(
+          bloc.state.entries.map((e) => e.id),
+          ['e2'],
+          reason: 'stale emits must not resurrect deleted entries (#205)',
+        );
+      },
+    );
   });
 
   group('todayCategoryCounts (#154)', () {

--- a/test/features/daily_journal/journal_bloc_test.dart
+++ b/test/features/daily_journal/journal_bloc_test.dart
@@ -1110,6 +1110,56 @@ void main() {
     );
   });
 
+  group('DeleteEntry optimistic removal (#205)', () {
+    late MockJournalRepository mockRepository;
+
+    setUp(() {
+      mockRepository = MockJournalRepository();
+    });
+
+    blocTest<JournalBloc, JournalState>(
+      'removes the entry from entries without waiting for the stream',
+      setUp: () {
+        when(
+          () => mockRepository.deleteCategoryEntry(any(), any()),
+        ).thenAnswer((_) async {});
+        when(() => mockRepository.getStreakData()).thenAnswer(
+          (_) async => const StreakData(
+            currentStreak: 0,
+            longestStreak: 0,
+            lastJournalDate: null,
+          ),
+        );
+      },
+      build: () => JournalBloc(repository: mockRepository),
+      seed: () => JournalState(
+        status: JournalStatus.loaded,
+        selectedDate: DateTime(2026, 3, 1),
+        entries: [
+          CategoryEntry(
+            id: 'e1',
+            categoryId: 'positive',
+            text: 'doomed',
+            createdAt: DateTime(2026, 3, 1),
+          ),
+          CategoryEntry(
+            id: 'e2',
+            categoryId: 'gratitude',
+            text: 'survivor',
+            createdAt: DateTime(2026, 3, 1),
+          ),
+        ],
+      ),
+      act: (bloc) => bloc.add(const DeleteEntry('e1')),
+      verify: (bloc) {
+        // No stream emit happened (mock never subscribed) — the list must
+        // update optimistically, like adds do (#44 pattern).
+        expect(bloc.state.entries.map((e) => e.id), ['e2']);
+        expect(bloc.state.status, JournalStatus.loaded);
+      },
+    );
+  });
+
   group('todayCategoryCounts (#154)', () {
     late MockJournalRepository mockRepository;
 


### PR DESCRIPTION
## Summary

Finishes the `dev/state-management-bugs` workstream's two remaining Ready issues, plus one product bug and two CI-script breaks the new E2E suite flushed out on its first runs.

Fixes #110
Fixes #162
Fixes #205
Refs #206, #44, #154, #190

## Key Decisions

- **#110**: `markEntriesReviewed` takes plain `(date, entryId)` records (no bloc-type import into the data layer), chunks at Firestore's 500-op batch limit; the bloc's all-or-nothing call makes its optimistic revert semantically correct.
- **#162 scope adaptations**: the issue's "progress card shows selected date label" item predated #154's resolution and described the inverse — the E2E asserts the new today-sourced contract. The radial-checkmark E2E is deferred to #190 (`CircularMenuItem` accepts no `Semantics`); it's covered at widget level. Past dates are selected via journal chevrons (calendar day cells aren't actionable in the web semantics tree); assertions use semantics labels (Flutter web exposes no text DOM inside `Semantics` wrappers).
- **#205 (found by this suite)**: `deletes an entry` fails on a main-based build too — deletes relied entirely on the stream whose post-delete emit is unreliable on the web SDK. Entry removal is now optimistic, mirroring #44's add path.
- **device-test.sh (found by this suite)**: Maestro never received `DEVICE_TEST_EMAIL` (flows can't read plain exports — login hung at the account picker since fa97007), and between-flow cleanup silently no-oped (auth:export lookup finds nothing; now loads `DEVICE_TEST_UID` from .env). Gate 1.5's success-on-skip is tracked separately in #206.
- **Flow stabilization**: regex asserts for streak-suffixed labels and the typographic nudge apostrophe; `retryTapIfNoChange: false` on radial taps (the retry landed on the open menu's backdrop and dismissed it).

## Test Plan

- [x] 3 new repo tests (batch write), 2 new bloc tests (single batch call, error revert), 1 new bloc test (#205 optimistic delete)
- [x] Full Flutter suite green (815 tests), `flutter analyze` clean (7 pre-existing infos)
- [x] Playwright: 43/43 green including 3 new state-regression specs (cross-date persistence, delete+Undo on the correct date, today-sourced progress card)
- [x] Device (Pixel 9a, real Firebase): full suite 11/14 → the 3 failures diagnosed as flow bugs, repaired, and individually re-verified passing — including the #189 restart flow

## Tester Checklist

- [ ] Delete an entry — it disappears immediately (web and Android)
- [ ] Delete, then tap Undo — the entry comes back on the same date
- [ ] In weekly review, mark several entries reviewed — they all stick

🤖 Generated with [Claude Code](https://claude.com/claude-code)