### PR TITLE
sync: main (post-#209) into dev/radial-menu

### DIFF
--- a/.maestro/journal/radial-menu-position-flow.yaml
+++ b/.maestro/journal/radial-menu-position-flow.yaml
@@ -11,6 +11,7 @@ tags:
 # Test 1: Tap mid-calendar date — menu should open near it
 - tapOn:
     point: "7%,35%"
+    retryTapIfNoChange: false
 - extendedWaitUntil:
     visible: "Start voice call"
     timeout: 5000
@@ -26,7 +27,8 @@ tags:
 
 # Test 2: Tap top-row date — menu should clamp within bounds
 - tapOn:
-    point: "37%,26%"
+    point: "37%,30%"
+    retryTapIfNoChange: false
 - extendedWaitUntil:
     visible: "Start voice call"
     timeout: 5000
@@ -43,6 +45,7 @@ tags:
 # Test 3: Tap bottom-row date
 - tapOn:
     point: "7%,44%"
+    retryTapIfNoChange: false
 - extendedWaitUntil:
     visible: "Start voice call"
     timeout: 5000

--- a/.maestro/state/data-loads-after-restart.yaml
+++ b/.maestro/state/data-loads-after-restart.yaml
@@ -1,0 +1,46 @@
+appId: com.dytty.dytty
+name: "State: data loads on app restart without interaction"
+tags:
+  - state
+  - regression
+---
+# Regression test for #189/#49: calendar markers, category icons and the
+# progress card must reflect today's entries right after a cold start,
+# with zero user interaction.
+
+- runFlow: "../helpers/login.yaml"
+
+# Clean slate for this flow
+- assertVisible: "Progress 0 of 5"
+
+# Ensure today has one entry
+- tapOn: "Today button"
+- waitForAnimationToEnd
+- tapOn: "Add Positive Things entry"
+- waitForAnimationToEnd
+- tapOn: "What good things happened today.*"
+- eraseText
+- inputText: "Restart persistence entry"
+- tapOn: "Save"
+- waitForAnimationToEnd:
+    timeout: 5000
+- assertVisible: ".*Restart persistence entry.*"
+
+- back
+- waitForAnimationToEnd:
+    timeout: 5000
+- assertVisible: "Progress 1 of 5.*"
+
+# Kill the app and relaunch WITHOUT clearing state — auth session and
+# Firestore cache persist, mirroring a real user reopening the app.
+- stopApp
+- launchApp
+- waitForAnimationToEnd:
+    timeout: 15000
+- waitForAnimationToEnd:
+    timeout: 10000
+
+# Dashboard must reflect today's entry with no interaction (#189/#49)
+- assertVisible: "Progress 1 of 5.*"
+
+- takeScreenshot: ".maestro/screenshots/latest/state/bug189-progress-after-restart"

--- a/.maestro/state/delete-last-entry-ring-unfills.yaml
+++ b/.maestro/state/delete-last-entry-ring-unfills.yaml
@@ -1,0 +1,48 @@
+appId: com.dytty.dytty
+name: "State: deleting the last entry unfills the ring and restores the nudge"
+tags:
+  - state
+  - regression
+---
+# Regression test for #162: removing a date's only entry must clear its
+# marker — ring empties, progress drops, nudge banner returns.
+
+- runFlow: "../helpers/login.yaml"
+
+- assertVisible: "Progress 0 of 5"
+
+# Add a single entry today
+- tapOn: "Today button"
+- waitForAnimationToEnd
+- tapOn: "Add Positive Things entry"
+- waitForAnimationToEnd
+- tapOn: "What good things happened today.*"
+- eraseText
+- inputText: "Entry to delete"
+- tapOn: "Save"
+- waitForAnimationToEnd:
+    timeout: 5000
+- assertVisible: ".*Entry to delete.*"
+
+- back
+- waitForAnimationToEnd:
+    timeout: 5000
+- assertVisible: "Progress 1 of 5.*"
+
+# Delete the entry
+- tapOn: "Today button"
+- waitForAnimationToEnd
+- tapOn: "Delete entry"
+- waitForAnimationToEnd:
+    timeout: 5000
+
+# Back home: ring unfilled, nudge back (#162 checklist: date key
+# removed from markers). ".*" suffixes: streak text may follow the
+# progress label, and the nudge apostrophe is typographic.
+- back
+- waitForAnimationToEnd:
+    timeout: 5000
+- assertVisible: "Progress 0 of 5.*"
+- assertVisible: "You haven.*journaled today.*"
+
+- takeScreenshot: ".maestro/screenshots/latest/state/162-delete-ring-unfills"

--- a/.maestro/state/past-date-ring-fills.yaml
+++ b/.maestro/state/past-date-ring-fills.yaml
@@ -1,0 +1,42 @@
+appId: com.dytty.dytty
+name: "State: adding entry on a past date fills that date's ring, not today's"
+tags:
+  - state
+  - regression
+---
+# Regression test for #162 (state-management E2E): an entry added on a
+# past date must mark THAT date — today's dashboard stays untouched.
+
+- runFlow: "../helpers/login.yaml"
+
+# Clean slate
+- assertVisible: "Progress 0 of 5"
+
+# Open today's journal and step back one day
+- tapOn: "Today button"
+- waitForAnimationToEnd
+- tapOn: "Previous day"
+- waitForAnimationToEnd
+
+# Add an entry on the past date
+- tapOn: "Add Positive Things entry"
+- waitForAnimationToEnd
+- tapOn: "What good things happened today.*"
+- eraseText
+- inputText: "Past date ring entry"
+- tapOn: "Save"
+- waitForAnimationToEnd:
+    timeout: 5000
+- assertVisible: ".*Past date ring entry.*"
+
+# Back to home: today's progress must STILL be 0 of 5 — the entry
+# belongs to yesterday, not today. (".*" — yesterday's entry bumps the
+# streak, so the label gains a ", streak 1 day" suffix. Apostrophe in
+# the nudge is typographic; match with ".*" like sibling flows.)
+- back
+- waitForAnimationToEnd:
+    timeout: 5000
+- assertVisible: "Progress 0 of 5.*"
+- assertVisible: "You haven.*journaled today.*"
+
+- takeScreenshot: ".maestro/screenshots/latest/state/162-past-date-ring"

--- a/e2e/state-regression.spec.ts
+++ b/e2e/state-regression.spec.ts
@@ -1,0 +1,143 @@
+import { test, expect, Page } from '@playwright/test';
+import {
+  waitForFlutterReady,
+  clickByLabel,
+  signInAnonymously,
+  clearEmulatorAuth,
+  clearEmulatorFirestore,
+} from './helpers';
+
+/**
+ * State-management E2E regression suite (#162).
+ *
+ * Covers the UI-wiring paths bloc tests cannot see:
+ * - entries surviving cross-date navigation (#153 family)
+ * - delete + Undo restoring on the correct date
+ * - progress card staying today-sourced when a past date is selected
+ *   (#154 contract — the card NEVER switches to the selected date)
+ *
+ * "Radial menu checkmarks" from the issue checklist is covered at widget
+ * level (home_screen_radial_menu_test: badges-from-state); its E2E needs
+ * accessible labels on CircularMenuItem bubbles, deferred to the #190
+ * menu rework.
+ */
+
+/** Adds an entry in a category on the daily journal screen. */
+async function addEntry(page: Page, categoryName: string, text: string) {
+  await page.getByRole('button', { name: `Add ${categoryName} entry` }).click();
+  const textField = page.getByRole('textbox');
+  await expect(textField).toBeVisible({ timeout: 10_000 });
+  await textField.fill(text);
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(page.getByLabel(`Journal entry: ${text}`)).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+test.describe('State regression: cross-date navigation and undo', () => {
+  test.beforeEach(async ({ page }) => {
+    await clearEmulatorAuth();
+    await clearEmulatorFirestore();
+    await page.goto('/');
+    await waitForFlutterReady(page);
+    await signInAnonymously(page);
+  });
+
+  test('entry added on a past date survives A -> B -> A navigation', async ({
+    page,
+  }) => {
+    // Go to today's journal, then step back one day (date A = yesterday).
+    await clickByLabel(page, 'Today button');
+    await expect(page.getByLabel('Positive Things category')).toBeVisible({
+      timeout: 10_000,
+    });
+    await page.getByRole('button', { name: 'Previous day' }).click();
+    await addEntry(page, 'Positive Things', 'Yesterday entry A');
+
+    // Navigate to date B (two days ago), then back to A.
+    await page.getByRole('button', { name: 'Previous day' }).click();
+    await expect(
+      page.getByLabel('Journal entry: Yesterday entry A'),
+    ).not.toBeVisible({ timeout: 10_000 });
+    await page.getByRole('button', { name: 'Next day' }).click();
+
+    // Entry must still be on date A.
+    await expect(
+      page.getByLabel('Journal entry: Yesterday entry A'),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('delete then Undo restores the entry on the correct date', async ({
+    page,
+  }) => {
+    // Add an entry on yesterday (a non-today date so a wrong-date restore
+    // would be visible as a failure).
+    await clickByLabel(page, 'Today button');
+    await expect(page.getByLabel('Positive Things category')).toBeVisible({
+      timeout: 10_000,
+    });
+    await page.getByRole('button', { name: 'Previous day' }).click();
+    await addEntry(page, 'Positive Things', 'Undo target entry');
+
+    // Delete it, then Undo from the snackbar. (No confirm dialog exists —
+    // delete is optimistic with an Undo snackbar; if a dialog ever
+    // appears, the next assertion fails loudly instead of being skipped.)
+    await page.getByRole('button', { name: 'Delete entry' }).first().click();
+    await expect(
+      page.getByLabel('Journal entry: Undo target entry'),
+    ).not.toBeVisible({ timeout: 10_000 });
+    await page.getByRole('button', { name: 'Undo' }).click();
+
+    // Restored on this (past) date...
+    await expect(
+      page.getByLabel('Journal entry: Undo target entry'),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // ...and NOT on today: navigate to today and assert absence.
+    await page.getByRole('button', { name: 'Next day' }).click();
+    await expect(
+      page.getByLabel('Journal entry: Undo target entry'),
+    ).not.toBeVisible({ timeout: 10_000 });
+
+    // Round-trip back to the past date — still there (persisted, not
+    // just optimistic state).
+    await page.getByRole('button', { name: 'Previous day' }).click();
+    await expect(
+      page.getByLabel('Journal entry: Undo target entry'),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('progress card stays today-sourced when a past date is selected (#154)', async ({
+    page,
+  }) => {
+    // Add one entry today so today's progress is 1 of 5.
+    await clickByLabel(page, 'Today button');
+    await expect(page.getByLabel('Positive Things category')).toBeVisible({
+      timeout: 10_000,
+    });
+    await addEntry(page, 'Positive Things', 'Today progress source');
+
+    // Select a past date via the journal chevron (same SelectDate event a
+    // calendar tap dispatches; day cells aren't actionable on web and the
+    // radial overlay isn't needed for this contract).
+    await page.getByRole('button', { name: 'Previous day' }).click();
+    await expect(
+      page.getByLabel('Journal entry: Today progress source'),
+    ).not.toBeVisible({ timeout: 10_000 });
+
+    // Back to home — selectedDate is still yesterday (HomeScreen is not
+    // re-mounted on pop, so initState's SelectDate(today) does not fire).
+    await page.goBack();
+    await expect(page.getByRole('button', { name: 'Today button' })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // The dashboard must show TODAY's progress (1 of 5), not the selected
+    // past date's (0 entries) — pre-#154 code showed 'Progress 0 of 5'
+    // here. The card title isn't asserted: the Semantics wrapper means
+    // inner text isn't exposed to the DOM; the label carries the contract.
+    await expect(page.getByLabel('Progress 1 of 5')).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+});

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -9,13 +9,6 @@
       ]
     },
     {
-      "collectionGroup": "dailyEntries",
-      "queryScope": "COLLECTION",
-      "fields": [
-        { "fieldPath": "__name__", "order": "DESCENDING" }
-      ]
-    },
-    {
       "collectionGroup": "reviewSummaries",
       "queryScope": "COLLECTION",
       "fields": [

--- a/firestore.rules
+++ b/firestore.rules
@@ -20,6 +20,11 @@ service cloud.firestore {
       match /reviewSummaries/{summaryId} {
         allow read, write: if request.auth != null && request.auth.uid == userId;
       }
+
+      // Category configuration subcollection
+      match /categories/{categoryId} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
     }
 
     // Deny all other access

--- a/lib/data/repositories/journal_repository.dart
+++ b/lib/data/repositories/journal_repository.dart
@@ -157,6 +157,28 @@ class JournalRepository {
     await _categoryEntries(date).doc(entryId).update({'isReviewed': true});
   }
 
+  /// Firestore's WriteBatch operation limit.
+  static const _maxBatchOps = 500;
+
+  /// Marks many entries reviewed using batched writes (#110).
+  ///
+  /// Atomic per chunk of [_maxBatchOps] only: beyond 500 refs a later
+  /// chunk can fail after earlier ones committed. Review sessions are far
+  /// below that today; revisit if they ever approach the limit.
+  Future<void> markEntriesReviewed(
+    List<({String date, String entryId})> refs,
+  ) async {
+    for (var i = 0; i < refs.length; i += _maxBatchOps) {
+      final batch = _firestore.batch();
+      for (final ref in refs.skip(i).take(_maxBatchOps)) {
+        batch.update(_categoryEntries(ref.date).doc(ref.entryId), {
+          'isReviewed': true,
+        });
+      }
+      await batch.commit();
+    }
+  }
+
   /// Saves or updates a review summary.
   /// Upserts by categoryId + weekStart — updates if exists, creates if not.
   Future<void> saveReviewSummary(ReviewSummary summary) async {
@@ -241,9 +263,10 @@ class JournalRepository {
   /// Computes streak data by walking dailyEntries backward from today.
   /// Returns {currentStreak, longestStreak, lastJournalDate}.
   Future<StreakData> getStreakData() async {
-    final snapshot = await _dailyEntriesCollection
-        .orderBy(FieldPath.documentId, descending: true)
-        .get();
+    // No server-side orderBy: doc IDs are collected into a Set and sorted
+    // client-side below. orderBy(__name__ DESC) required a composite index
+    // that was never deployed, failing every cold start (#170, #189).
+    final snapshot = await _dailyEntriesCollection.get();
 
     final dates = snapshot.docs.map((doc) => doc.id).toSet();
     if (dates.isEmpty) {

--- a/lib/features/category_detail/bloc/category_detail_bloc.dart
+++ b/lib/features/category_detail/bloc/category_detail_bloc.dart
@@ -457,19 +457,18 @@ class CategoryDetailBloc
 
     emit(state.copyWith(recentEntries: updatedGroups));
 
-    // Persist to Firestore
-    for (final ref in event.entries) {
-      try {
-        await _repository.markEntryReviewed(ref.date, ref.entryId);
-      } catch (e) {
-        emit(
-          state.copyWith(
-            recentEntries: previousGroups,
-            error: 'Failed to mark entry as reviewed: $e',
-          ),
-        );
-        return;
-      }
+    // Persist to Firestore in a single batch write (#110)
+    try {
+      await _repository.markEntriesReviewed([
+        for (final ref in event.entries) (date: ref.date, entryId: ref.entryId),
+      ]);
+    } catch (e) {
+      emit(
+        state.copyWith(
+          recentEntries: previousGroups,
+          error: 'Failed to mark entries as reviewed: $e',
+        ),
+      );
     }
   }
 

--- a/lib/features/daily_journal/bloc/journal_bloc.dart
+++ b/lib/features/daily_journal/bloc/journal_bloc.dart
@@ -113,6 +113,17 @@ class JournalState extends Equatable {
   final DateTime selectedDate;
   final List<CategoryEntry> entries;
   final Map<String, Map<String, int>> monthCategoryMarkers;
+
+  /// Today's per-category entry counts, independent of which month
+  /// [monthCategoryMarkers] currently holds. Survives month navigation so
+  /// the dashboard (nudge + progress card) always reflects today (#154).
+  /// Stored with the date it was computed for; read through
+  /// [todayCategoryCounts] which returns empty once that date has passed
+  /// (midnight rollover must not show yesterday as "today").
+  final Map<String, int> _todayCategoryCounts;
+
+  /// 'yyyy-MM-dd' the stored counts belong to.
+  final String todayCountsDate;
   final int currentStreak;
   final String? lastJournalDate;
   final String? error;
@@ -124,22 +135,36 @@ class JournalState extends Equatable {
     DateTime? selectedDate,
     this.entries = const [],
     this.monthCategoryMarkers = const {},
+    Map<String, int>? todayCategoryCounts,
+    String? todayCountsDate,
     this.currentStreak = 0,
     this.lastJournalDate,
     this.error,
-  }) : selectedDate = selectedDate ?? DateTime.now();
+  }) : selectedDate = selectedDate ?? DateTime.now(),
+       // Derive from markers when not explicitly provided, so directly
+       // constructed states (tests, initial load) stay consistent.
+       _todayCategoryCounts =
+           todayCategoryCounts ??
+           Map<String, int>.from(
+             monthCategoryMarkers[_dateFormat.format(DateTime.now())] ??
+                 const {},
+           ),
+       todayCountsDate = todayCountsDate ?? _dateFormat.format(DateTime.now());
 
   String get selectedDateString => _dateFormat.format(selectedDate);
 
   /// Backward-compatible derived getter — dates that have any entries.
   Set<String> get daysWithEntries => monthCategoryMarkers.keys.toSet();
 
-  /// Whether the user has journaled today (based on monthCategoryMarkers).
-  bool get journaledToday {
-    final now = DateTime.now();
-    final todayStr = _dateFormat.format(now);
-    return daysWithEntries.contains(todayStr);
-  }
+  /// Today's counts, empty when the stored counts are for a past date
+  /// (midnight rollover).
+  Map<String, int> get todayCategoryCounts =>
+      todayCountsDate == _dateFormat.format(DateTime.now())
+      ? _todayCategoryCounts
+      : const {};
+
+  /// Whether the user has journaled today.
+  bool get journaledToday => todayCategoryCounts.isNotEmpty;
 
   List<CategoryEntry> entriesForCategory(String categoryId) {
     return entries.where((e) => e.categoryId == categoryId).toList();
@@ -150,6 +175,7 @@ class JournalState extends Equatable {
     DateTime? selectedDate,
     List<CategoryEntry>? entries,
     Map<String, Map<String, int>>? monthCategoryMarkers,
+    Map<String, int>? todayCategoryCounts,
     int? currentStreak,
     String? lastJournalDate,
     String? error,
@@ -159,6 +185,13 @@ class JournalState extends Equatable {
       selectedDate: selectedDate ?? this.selectedDate,
       entries: entries ?? this.entries,
       monthCategoryMarkers: monthCategoryMarkers ?? this.monthCategoryMarkers,
+      todayCategoryCounts: todayCategoryCounts ?? _todayCategoryCounts,
+      // Fresh counts are always computed "for now" — restamp their date.
+      // Preserved counts keep their original date so the rollover gate
+      // in the getter stays correct.
+      todayCountsDate: todayCategoryCounts != null
+          ? JournalState._dateFormat.format(DateTime.now())
+          : todayCountsDate,
       currentStreak: currentStreak ?? this.currentStreak,
       lastJournalDate: lastJournalDate ?? this.lastJournalDate,
       error: error,
@@ -171,6 +204,8 @@ class JournalState extends Equatable {
     selectedDate,
     entries,
     monthCategoryMarkers,
+    _todayCategoryCounts,
+    todayCountsDate,
     currentStreak,
     lastJournalDate,
     error,
@@ -187,6 +222,12 @@ class JournalBloc extends Bloc<JournalEvent, JournalState> {
 
   /// Active subscription to the selected date's entries.
   StreamSubscription<List<CategoryEntry>>? _entriesSubscription;
+
+  /// Tombstones for optimistically deleted entries: a snapshot generated
+  /// before the delete can arrive after it and resurrect the entry — and
+  /// on web the corrective post-delete emit is unreliable (#205).
+  /// Cleared on SelectDate (fresh subscription = fresh server truth).
+  final Set<String> _pendingDeletes = {};
 
   /// Exposes the repository for sibling blocs that share the same data source.
   JournalRepository get repository => _repository;
@@ -215,6 +256,20 @@ class JournalBloc extends Bloc<JournalEvent, JournalState> {
     return source.map((k, v) => MapEntry(k, Map<String, int>.from(v)));
   }
 
+  /// Today's counts from [markers] when ([year], [month]) is the current
+  /// month, else null so copyWith preserves the existing value (#154).
+  Map<String, int>? _todayCountsIfCurrentMonth(
+    Map<String, Map<String, int>> markers,
+    int year,
+    int month,
+  ) {
+    final now = DateTime.now();
+    if (year != now.year || month != now.month) return null;
+    return Map<String, int>.from(
+      markers[JournalState._dateFormat.format(now)] ?? const {},
+    );
+  }
+
   Future<void> _onLoadEntries(
     LoadEntries event,
     Emitter<JournalState> emit,
@@ -238,40 +293,75 @@ class JournalBloc extends Bloc<JournalEvent, JournalState> {
       state.copyWith(selectedDate: event.date, status: JournalStatus.loading),
     );
 
-    // Cancel previous date's subscription
+    // Cancel previous date's subscription; fresh subscription supersedes
+    // any pending delete tombstones.
     await _entriesSubscription?.cancel();
+    _pendingDeletes.clear();
 
-    try {
-      final dateString = JournalState._dateFormat.format(event.date);
+    final dateString = JournalState._dateFormat.format(event.date);
 
-      // Subscribe to entry stream (cache-first, auto-updates on sync)
-      _entriesSubscription = _repository
-          .watchCategoryEntries(dateString)
-          .listen((entries) => add(_EntriesUpdated(entries)));
+    // Subscribe to entry stream (cache-first, auto-updates on sync)
+    _entriesSubscription = _repository
+        .watchCategoryEntries(dateString)
+        .listen((entries) => add(_EntriesUpdated(entries)));
 
-      // Fetch markers and streak in parallel
-      final results = await Future.wait([
-        _repository.getMonthCategoryMarkers(event.date.year, event.date.month),
-        _repository.getStreakData(),
-      ]);
+    // Fetch markers and streak independently: one failure must not discard
+    // the other's data (#189/#49/#151 — a failing streak query silently
+    // dropped successfully-fetched month markers).
+    String? loadError;
 
-      final markers = results[0] as Map<String, Map<String, int>>;
-      final streak = results[1] as StreakData;
-
-      final key = _cacheKey(event.date.year, event.date.month);
-      _markerCache[key] = markers;
-
-      emit(
-        state.copyWith(
-          status: JournalStatus.loaded,
-          monthCategoryMarkers: markers,
-          currentStreak: streak.currentStreak,
-          lastJournalDate: streak.lastJournalDate,
-        ),
-      );
-    } catch (e) {
-      emit(state.copyWith(status: JournalStatus.error, error: e.toString()));
+    Future<Map<String, Map<String, int>>?> fetchMarkers() async {
+      try {
+        return await _repository.getMonthCategoryMarkers(
+          event.date.year,
+          event.date.month,
+        );
+      } catch (e) {
+        loadError = e.toString();
+        return null;
+      }
     }
+
+    Future<StreakData?> fetchStreak() async {
+      try {
+        return await _repository.getStreakData();
+      } catch (e) {
+        loadError ??= e.toString();
+        return null;
+      }
+    }
+
+    final results = await Future.wait<Object?>([fetchMarkers(), fetchStreak()]);
+    final markers = results[0] as Map<String, Map<String, int>>?;
+    final streak = results[1] as StreakData?;
+
+    if (markers != null) {
+      _markerCache[_cacheKey(event.date.year, event.date.month)] = markers;
+    }
+
+    // Nothing usable loaded → error state; partial data → loaded with the
+    // error surfaced so the UI can show a banner with retry (#170).
+    if (markers == null && streak == null) {
+      emit(state.copyWith(status: JournalStatus.error, error: loadError));
+      return;
+    }
+
+    emit(
+      state.copyWith(
+        status: JournalStatus.loaded,
+        monthCategoryMarkers: markers ?? state.monthCategoryMarkers,
+        todayCategoryCounts: markers != null
+            ? _todayCountsIfCurrentMonth(
+                markers,
+                event.date.year,
+                event.date.month,
+              )
+            : null,
+        currentStreak: streak?.currentStreak ?? state.currentStreak,
+        lastJournalDate: streak?.lastJournalDate ?? state.lastJournalDate,
+        error: loadError,
+      ),
+    );
   }
 
   /// Shared optimistic update for both AddEntry and AddVoiceEntry.
@@ -304,11 +394,21 @@ class JournalBloc extends Bloc<JournalEvent, JournalState> {
       optimisticStreak = state.currentStreak + 1;
     }
 
+    // Increment today's counts from their current value — the marker map
+    // may hold a different month after calendar navigation, so deriving
+    // from it would wipe today's other categories (review finding, #154).
+    Map<String, int>? todayCounts;
+    if (dateString == JournalState._dateFormat.format(DateTime.now())) {
+      todayCounts = Map<String, int>.from(state.todayCategoryCounts);
+      todayCounts[categoryId] = (todayCounts[categoryId] ?? 0) + 1;
+    }
+
     emit(
       state.copyWith(
         status: JournalStatus.loaded,
         entries: [...state.entries.where((e) => e.id != created.id), created],
         monthCategoryMarkers: currentMarkers,
+        todayCategoryCounts: todayCounts,
         currentStreak: optimisticStreak,
         lastJournalDate: dateString,
       ),
@@ -414,6 +514,7 @@ class JournalBloc extends Bloc<JournalEvent, JournalState> {
         state.selectedDateString,
         event.entryId,
       );
+      _pendingDeletes.add(event.entryId);
       // Entries are updated via the stream subscription (_EntriesUpdated).
       // Optimistically update markers only.
       final currentMarkers = _cloneMarkers(state.monthCategoryMarkers);
@@ -437,10 +538,29 @@ class JournalBloc extends Bloc<JournalEvent, JournalState> {
       );
       _markerCache[focusKey] = currentMarkers;
 
+      // Decrement today's counts from their current value, not from the
+      // marker map (which may hold another month — review finding, #154).
+      Map<String, int>? todayCounts;
+      if (dateStr == JournalState._dateFormat.format(DateTime.now()) &&
+          deletedEntry != null) {
+        todayCounts = Map<String, int>.from(state.todayCategoryCounts);
+        final count = (todayCounts[deletedEntry.categoryId] ?? 1) - 1;
+        if (count <= 0) {
+          todayCounts.remove(deletedEntry.categoryId);
+        } else {
+          todayCounts[deletedEntry.categoryId] = count;
+        }
+      }
+
       emit(
         state.copyWith(
           status: JournalStatus.loaded,
+          // Optimistic removal — the web SDK's snapshots emit after a
+          // local delete is unreliable (#205), same reason adds are
+          // optimistic (#44). The stream reconciles later if needed.
+          entries: state.entries.where((e) => e.id != event.entryId).toList(),
           monthCategoryMarkers: currentMarkers,
+          todayCategoryCounts: todayCounts,
         ),
       );
       // Refresh streak in background (non-blocking for UI)
@@ -467,7 +587,17 @@ class JournalBloc extends Bloc<JournalEvent, JournalState> {
     try {
       final key = _cacheKey(event.year, event.month);
       if (_markerCache.containsKey(key)) {
-        emit(state.copyWith(monthCategoryMarkers: _markerCache[key]));
+        final cached = _markerCache[key]!;
+        emit(
+          state.copyWith(
+            monthCategoryMarkers: cached,
+            todayCategoryCounts: _todayCountsIfCurrentMonth(
+              cached,
+              event.year,
+              event.month,
+            ),
+          ),
+        );
         return;
       }
       final markers = await _repository.getMonthCategoryMarkers(
@@ -475,7 +605,16 @@ class JournalBloc extends Bloc<JournalEvent, JournalState> {
         event.month,
       );
       _markerCache[key] = markers;
-      emit(state.copyWith(monthCategoryMarkers: markers));
+      emit(
+        state.copyWith(
+          monthCategoryMarkers: markers,
+          todayCategoryCounts: _todayCountsIfCurrentMonth(
+            markers,
+            event.year,
+            event.month,
+          ),
+        ),
+      );
     } catch (_) {
       // Non-critical — silently fail for markers
     }
@@ -503,7 +642,19 @@ class JournalBloc extends Bloc<JournalEvent, JournalState> {
     final status = state.status == JournalStatus.saving
         ? JournalStatus.saving
         : JournalStatus.loaded;
-    emit(state.copyWith(status: status, entries: event.entries));
+    // Preserve any pending load error — the cache-first stream otherwise
+    // masks marker/streak failures and the user never sees feedback (#170).
+    // Filter tombstoned deletes: a pre-delete snapshot arriving late must
+    // not resurrect an optimistically removed entry (#205).
+    emit(
+      state.copyWith(
+        status: status,
+        entries: event.entries
+            .where((e) => !_pendingDeletes.contains(e.id))
+            .toList(),
+        error: state.error,
+      ),
+    );
   }
 
   @override

--- a/lib/features/daily_journal/home_screen.dart
+++ b/lib/features/daily_journal/home_screen.dart
@@ -6,7 +6,6 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:intl/intl.dart';
 import 'package:table_calendar/table_calendar.dart';
 import 'package:dytty/data/models/category_config.dart';
-import 'package:dytty/data/models/category_entry.dart';
 import 'package:dytty/features/auth/bloc/auth_bloc.dart';
 import 'package:dytty/features/daily_journal/bloc/journal_bloc.dart';
 import 'package:dytty/features/settings/cubit/category_cubit.dart';
@@ -154,6 +153,27 @@ class _HomeScreenState extends State<HomeScreen> {
                     .animate()
                     .fadeIn(duration: 400.ms)
                     .slideX(begin: -0.05, end: 0, duration: 400.ms),
+
+                // Load failure feedback with retry (#170)
+                if (journalState.error != null)
+                  MaterialBanner(
+                    leading: Icon(
+                      Icons.cloud_off_rounded,
+                      color: theme.colorScheme.error,
+                    ),
+                    content: const Text("Couldn't load your journal data."),
+                    actions: [
+                      TextButton(
+                        onPressed: () => context.read<JournalBloc>().add(
+                          SelectDate(journalState.selectedDate),
+                        ),
+                        child: const Text('Retry'),
+                      ),
+                    ],
+                  ),
+
+                if (journalState.status == JournalStatus.loading)
+                  const LinearProgressIndicator(minHeight: 2),
 
                 // Calendar
                 Padding(
@@ -304,9 +324,11 @@ class _HomeScreenState extends State<HomeScreen> {
                 Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 16),
                       child: _ProgressCard(
-                        entries: journalState.entries,
+                        // Always today's status, independent of the
+                        // selected date (#154).
+                        filledCategoryIds: journalState.todayCategoryCounts.keys
+                            .toSet(),
                         categories: categoryState.activeCategories,
-                        selectedDate: journalState.selectedDate,
                         currentStreak: journalState.currentStreak,
                         onCategoryTap: (categoryId) {
                           Navigator.pushNamed(
@@ -602,16 +624,14 @@ class _InitialsAvatar extends StatelessWidget {
 }
 
 class _ProgressCard extends StatelessWidget {
-  final List<CategoryEntry> entries;
+  final Set<String> filledCategoryIds;
   final List<CategoryConfig> categories;
   final int currentStreak;
-  final DateTime selectedDate;
   final void Function(String categoryId)? onCategoryTap;
 
   const _ProgressCard({
-    required this.entries,
+    required this.filledCategoryIds,
     required this.categories,
-    required this.selectedDate,
     this.currentStreak = 0,
     this.onCategoryTap,
   });
@@ -619,10 +639,6 @@ class _ProgressCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final filledCategoryIds = <String>{};
-    for (final entry in entries) {
-      filledCategoryIds.add(entry.categoryId);
-    }
     final total = categories.length;
     final filled = filledCategoryIds
         .intersection(categories.map((c) => c.id).toSet())
@@ -651,9 +667,7 @@ class _ProgressCard extends StatelessWidget {
               Row(
                 children: [
                   Text(
-                    isSameDay(selectedDate, DateTime.now())
-                        ? "Today's Progress"
-                        : '${DateFormat('MMM d').format(selectedDate)} Progress',
+                    "Today's Progress",
                     style: theme.textTheme.titleSmall?.copyWith(
                       fontWeight: FontWeight.w600,
                     ),

--- a/scripts/device-test.sh
+++ b/scripts/device-test.sh
@@ -58,8 +58,16 @@ if [[ -d "$LOCALAPPDATA/Android/Sdk/platform-tools" ]]; then
 fi
 
 # ── Load test email from .env if not set ──────────────
+# Anchored grep + -f2-: skip commented lines, keep values containing '='.
 if [[ -z "${DEVICE_TEST_EMAIL:-}" && -f "$PROJECT_DIR/.env" ]]; then
-  DEVICE_TEST_EMAIL=$(grep DEVICE_TEST_EMAIL "$PROJECT_DIR/.env" | cut -d= -f2 || true)
+  DEVICE_TEST_EMAIL=$(grep '^DEVICE_TEST_EMAIL=' "$PROJECT_DIR/.env" | cut -d= -f2- || true)
+fi
+# UID powers device-cleanup.sh's direct path — the auth:export email
+# lookup fallback does not work (#206), so cleanup silently no-ops
+# between flows and every flow after the first inherits stale data.
+if [[ -z "${DEVICE_TEST_UID:-}" && -f "$PROJECT_DIR/.env" ]]; then
+  DEVICE_TEST_UID=$(grep '^DEVICE_TEST_UID=' "$PROJECT_DIR/.env" | cut -d= -f2- || true)
+  export DEVICE_TEST_UID
 fi
 if [[ -z "${DEVICE_TEST_EMAIL:-}" ]]; then
   echo "ERROR: DEVICE_TEST_EMAIL not set. Add to .env or export it."
@@ -167,12 +175,18 @@ echo "=== Running Maestro flows on device ==="
 echo "  Screenshots: $SCREENSHOT_DIR"
 echo ""
 
-MAESTRO_BASE="maestro test"
-MAESTRO_BASE="$MAESTRO_BASE --debug-output $SCREENSHOT_DIR"
-MAESTRO_BASE="$MAESTRO_BASE --format junit"
+# Array form: values stay single words under expansion (quoting review
+# finding — the email is the first variable-bearing argument here).
+# Maestro flows cannot read plain shell exports: ${DEVICE_TEST_EMAIL} in
+# login-device.yaml only resolves from -e params. Without this the account
+# tap never matches and login hangs (#206, regression from fa97007).
+MAESTRO_ARGS=(maestro test
+  --debug-output "$SCREENSHOT_DIR"
+  --format junit
+  -e "DEVICE_TEST_EMAIL=$DEVICE_TEST_EMAIL")
 
 if [[ -n "$TAGS" ]]; then
-  MAESTRO_BASE="$MAESTRO_BASE --include-tags=$TAGS"
+  MAESTRO_ARGS+=("--include-tags=$TAGS")
 fi
 
 FLOW_RESULTS_DIR="$SCREENSHOT_DIR/flow-results"
@@ -197,7 +211,7 @@ for dir in "$MAESTRO_DIR"/*/; do
     if [[ "$SKIP_CLEANUP" == false ]] && command -v firebase &>/dev/null; then
       bash "$SCRIPT_DIR/device-cleanup.sh" 2>/dev/null || true
     fi
-    if ! $MAESTRO_BASE --output "$FLOW_RESULTS_DIR/$FLOW_INDEX.xml" "$flow" 2>&1; then
+    if ! "${MAESTRO_ARGS[@]}" --output "$FLOW_RESULTS_DIR/$FLOW_INDEX.xml" "$flow" 2>&1; then
       TEST_FAILED=true
     fi
     FLOW_INDEX=$((FLOW_INDEX + 1))

--- a/test/data/repositories/journal_repository_test.dart
+++ b/test/data/repositories/journal_repository_test.dart
@@ -393,6 +393,82 @@ void main() {
       });
     });
 
+    group('markEntriesReviewed (batch, #110)', () {
+      test('marks all referenced entries reviewed across dates', () async {
+        final a = await repository.addCategoryEntry(
+          '2026-03-01',
+          'positive',
+          'x',
+        );
+        final b = await repository.addCategoryEntry(
+          '2026-03-01',
+          'gratitude',
+          'y',
+        );
+        final c = await repository.addCategoryEntry(
+          '2026-03-02',
+          'positive',
+          'z',
+        );
+
+        await repository.markEntriesReviewed([
+          (date: '2026-03-01', entryId: a.id),
+          (date: '2026-03-01', entryId: b.id),
+          (date: '2026-03-02', entryId: c.id),
+        ]);
+
+        final day1 = await repository.getCategoryEntries('2026-03-01');
+        final day2 = await repository.getCategoryEntries('2026-03-02');
+        expect(day1.firstWhere((e) => e.id == a.id).isReviewed, true);
+        expect(day1.firstWhere((e) => e.id == b.id).isReviewed, true);
+        expect(day2.firstWhere((e) => e.id == c.id).isReviewed, true);
+      });
+
+      test('leaves unreferenced entries untouched', () async {
+        final a = await repository.addCategoryEntry(
+          '2026-03-01',
+          'positive',
+          'x',
+        );
+        final other = await repository.addCategoryEntry(
+          '2026-03-01',
+          'gratitude',
+          'y',
+        );
+
+        await repository.markEntriesReviewed([
+          (date: '2026-03-01', entryId: a.id),
+        ]);
+
+        final day = await repository.getCategoryEntries('2026-03-01');
+        expect(day.firstWhere((e) => e.id == other.id).isReviewed, false);
+      });
+
+      test('no-op on empty list', () async {
+        await repository.markEntriesReviewed(const []);
+      });
+
+      test('handles more refs than one batch chunk (501)', () async {
+        // Exercises the chunk-boundary arithmetic; fake_cloud_firestore
+        // does not enforce the 500-op limit itself.
+        final refs = <({String date, String entryId})>[];
+        for (var i = 0; i < 501; i++) {
+          final entry = await repository.addCategoryEntry(
+            '2026-03-01',
+            'positive',
+            'bulk $i',
+          );
+          refs.add((date: '2026-03-01', entryId: entry.id));
+        }
+
+        await repository.markEntriesReviewed(refs);
+
+        final entries = await repository.getCategoryEntries('2026-03-01');
+        expect(entries.length, 501);
+        expect(entries.every((e) => e.isReviewed), true);
+      });
+    });
+
     group('markEntryReviewed', () {
       test('sets isReviewed to true on an entry', () async {
         final entry = await repository.addCategoryEntry(

--- a/test/features/category_detail/bloc/category_detail_bloc_test.dart
+++ b/test/features/category_detail/bloc/category_detail_bloc_test.dart
@@ -478,11 +478,10 @@ void main() {
           true,
         ),
         // Firestore persist fails (no doc seeded), error emitted
-        // Note: second entry error is deduplicated by Equatable (same message)
         isA<CategoryDetailState>().having(
           (s) => s.error,
           'error',
-          contains('Failed to mark entry as reviewed'),
+          contains('Failed to mark entries as reviewed'),
         ),
       ],
     );
@@ -577,6 +576,7 @@ void main() {
     });
 
     setUpAll(() {
+      registerFallbackValue(const <({String date, String entryId})>[]);
       registerFallbackValue(
         ReviewSummary(
           id: '',
@@ -649,11 +649,74 @@ void main() {
     );
 
     blocTest<CategoryDetailBloc, CategoryDetailState>(
+      'MarkEntriesReviewed persists all refs via one batch call (#110)',
+      build: () => CategoryDetailBloc(repository: mockRepo, clock: fixedClock),
+      setUp: () {
+        when(
+          () => mockRepo.markEntriesReviewed(any()),
+        ).thenAnswer((_) async {});
+      },
+      seed: () => CategoryDetailState(
+        status: CategoryDetailStatus.loaded,
+        categoryId: 'positive',
+        recentEntries: [
+          DateGroup(
+            date: '2026-03-18',
+            displayDate: 'Today',
+            entries: [
+              CategoryEntry(
+                id: 'e1',
+                categoryId: 'positive',
+                text: 'Entry 1',
+                createdAt: DateTime(2026, 3, 18),
+                isReviewed: false,
+              ),
+            ],
+          ),
+          DateGroup(
+            date: '2026-03-17',
+            displayDate: 'Yesterday',
+            entries: [
+              CategoryEntry(
+                id: 'e2',
+                categoryId: 'positive',
+                text: 'Entry 2',
+                createdAt: DateTime(2026, 3, 17),
+                isReviewed: false,
+              ),
+            ],
+          ),
+        ],
+        hasRecentEntries: true,
+      ),
+      act: (bloc) => bloc.add(
+        const MarkEntriesReviewed(
+          entries: [
+            EntryReference(date: '2026-03-18', entryId: 'e1'),
+            EntryReference(date: '2026-03-17', entryId: 'e2'),
+          ],
+        ),
+      ),
+      verify: (bloc) {
+        final captured =
+            verify(
+                  () => mockRepo.markEntriesReviewed(captureAny()),
+                ).captured.single
+                as List<({String date, String entryId})>;
+        expect(captured, [
+          (date: '2026-03-18', entryId: 'e1'),
+          (date: '2026-03-17', entryId: 'e2'),
+        ]);
+        verifyNever(() => mockRepo.markEntryReviewed(any(), any()));
+      },
+    );
+
+    blocTest<CategoryDetailBloc, CategoryDetailState>(
       'MarkEntriesReviewed emits error when repo throws',
       build: () => CategoryDetailBloc(repository: mockRepo, clock: fixedClock),
       setUp: () {
         when(
-          () => mockRepo.markEntryReviewed(any(), any()),
+          () => mockRepo.markEntriesReviewed(any()),
         ).thenThrow(Exception('network failure'));
       },
       seed: () => CategoryDetailState(
@@ -700,7 +763,7 @@ void main() {
             .having(
               (s) => s.error,
               'error contains message',
-              contains('Failed to mark entry as reviewed'),
+              contains('Failed to mark entries as reviewed'),
             ),
       ],
     );

--- a/test/features/daily_journal/journal_bloc_test.dart
+++ b/test/features/daily_journal/journal_bloc_test.dart
@@ -1012,4 +1012,381 @@ void main() {
       ],
     );
   });
+
+  group('JournalBloc SelectDate resilience (#189/#49/#151/#170)', () {
+    late MockJournalRepository mockRepository;
+
+    const streak = StreakData(
+      currentStreak: 2,
+      longestStreak: 4,
+      lastJournalDate: '2026-03-01',
+    );
+    final markers = {
+      '2026-03-01': {'positive': 1},
+    };
+
+    setUp(() {
+      mockRepository = MockJournalRepository();
+    });
+
+    blocTest<JournalBloc, JournalState>(
+      'applies markers and surfaces error when getStreakData throws',
+      setUp: () {
+        when(
+          () => mockRepository.watchCategoryEntries(any()),
+        ).thenAnswer((_) => const Stream.empty());
+        when(
+          () => mockRepository.getMonthCategoryMarkers(any(), any()),
+        ).thenAnswer((_) async => markers);
+        when(
+          () => mockRepository.getStreakData(),
+        ).thenThrow(Exception('FAILED_PRECONDITION: index missing'));
+      },
+      build: () => JournalBloc(repository: mockRepository),
+      act: (bloc) => bloc.add(SelectDate(DateTime(2026, 3, 1))),
+      verify: (bloc) {
+        expect(bloc.state.status, JournalStatus.loaded);
+        expect(bloc.state.monthCategoryMarkers, markers);
+        expect(bloc.state.error, contains('FAILED_PRECONDITION'));
+      },
+    );
+
+    blocTest<JournalBloc, JournalState>(
+      'applies streak and surfaces error when getMonthCategoryMarkers throws',
+      setUp: () {
+        when(
+          () => mockRepository.watchCategoryEntries(any()),
+        ).thenAnswer((_) => const Stream.empty());
+        when(
+          () => mockRepository.getMonthCategoryMarkers(any(), any()),
+        ).thenThrow(Exception('markers failed'));
+        when(
+          () => mockRepository.getStreakData(),
+        ).thenAnswer((_) async => streak);
+      },
+      build: () => JournalBloc(repository: mockRepository),
+      act: (bloc) => bloc.add(SelectDate(DateTime(2026, 3, 1))),
+      verify: (bloc) {
+        expect(bloc.state.status, JournalStatus.loaded);
+        expect(bloc.state.currentStreak, 2);
+        expect(bloc.state.lastJournalDate, '2026-03-01');
+        expect(bloc.state.error, contains('markers failed'));
+      },
+    );
+
+    blocTest<JournalBloc, JournalState>(
+      'entry stream emission does not clear a pending load error',
+      setUp: () {
+        when(() => mockRepository.watchCategoryEntries(any())).thenAnswer(
+          (_) => Stream.value([
+            CategoryEntry(
+              id: 'e1',
+              categoryId: 'positive',
+              text: 'cached entry',
+              createdAt: DateTime(2026, 3, 1),
+            ),
+          ]),
+        );
+        when(
+          () => mockRepository.getMonthCategoryMarkers(any(), any()),
+        ).thenThrow(Exception('markers failed'));
+        when(
+          () => mockRepository.getStreakData(),
+        ).thenAnswer((_) async => streak);
+      },
+      build: () => JournalBloc(repository: mockRepository),
+      act: (bloc) async {
+        bloc.add(SelectDate(DateTime(2026, 3, 1)));
+        await Future.delayed(const Duration(milliseconds: 100));
+      },
+      verify: (bloc) {
+        expect(bloc.state.entries.length, 1);
+        expect(
+          bloc.state.error,
+          contains('markers failed'),
+          reason: 'stream emits must not mask load errors (#170)',
+        );
+      },
+    );
+  });
+
+  group('DeleteEntry optimistic removal (#205)', () {
+    late MockJournalRepository mockRepository;
+
+    setUp(() {
+      mockRepository = MockJournalRepository();
+    });
+
+    blocTest<JournalBloc, JournalState>(
+      'removes the entry from entries without waiting for the stream',
+      setUp: () {
+        when(
+          () => mockRepository.deleteCategoryEntry(any(), any()),
+        ).thenAnswer((_) async {});
+        when(() => mockRepository.getStreakData()).thenAnswer(
+          (_) async => const StreakData(
+            currentStreak: 0,
+            longestStreak: 0,
+            lastJournalDate: null,
+          ),
+        );
+      },
+      build: () => JournalBloc(repository: mockRepository),
+      seed: () => JournalState(
+        status: JournalStatus.loaded,
+        selectedDate: DateTime(2026, 3, 1),
+        entries: [
+          CategoryEntry(
+            id: 'e1',
+            categoryId: 'positive',
+            text: 'doomed',
+            createdAt: DateTime(2026, 3, 1),
+          ),
+          CategoryEntry(
+            id: 'e2',
+            categoryId: 'gratitude',
+            text: 'survivor',
+            createdAt: DateTime(2026, 3, 1),
+          ),
+        ],
+      ),
+      act: (bloc) => bloc.add(const DeleteEntry('e1')),
+      verify: (bloc) {
+        // No stream emit happened (mock never subscribed) — the list must
+        // update optimistically, like adds do (#44 pattern).
+        expect(bloc.state.entries.map((e) => e.id), ['e2']);
+        expect(bloc.state.status, JournalStatus.loaded);
+      },
+    );
+
+    blocTest<JournalBloc, JournalState>(
+      'a stale stream emit cannot resurrect a deleted entry',
+      setUp: () {
+        when(
+          () => mockRepository.deleteCategoryEntry(any(), any()),
+        ).thenAnswer((_) async {});
+        when(() => mockRepository.getStreakData()).thenAnswer(
+          (_) async => const StreakData(
+            currentStreak: 0,
+            longestStreak: 0,
+            lastJournalDate: null,
+          ),
+        );
+        when(
+          () => mockRepository.getMonthCategoryMarkers(any(), any()),
+        ).thenAnswer((_) async => {});
+      },
+      build: () => JournalBloc(repository: mockRepository),
+      seed: () => JournalState(
+        status: JournalStatus.loaded,
+        selectedDate: DateTime(2026, 3, 1),
+      ),
+      act: (bloc) async {
+        // Subscribe via SelectDate with a controllable stream, then emit a
+        // pre-delete snapshot AFTER the delete — the web SDK can deliver
+        // exactly this ordering (#205).
+        final controller = StreamController<List<CategoryEntry>>();
+        when(
+          () => mockRepository.watchCategoryEntries(any()),
+        ).thenAnswer((_) => controller.stream);
+
+        final e1 = CategoryEntry(
+          id: 'e1',
+          categoryId: 'positive',
+          text: 'doomed',
+          createdAt: DateTime(2026, 3, 1),
+        );
+        final e2 = CategoryEntry(
+          id: 'e2',
+          categoryId: 'gratitude',
+          text: 'survivor',
+          createdAt: DateTime(2026, 3, 1),
+        );
+
+        bloc.add(SelectDate(DateTime(2026, 3, 1)));
+        await Future.delayed(const Duration(milliseconds: 100));
+        controller.add([e1, e2]);
+        await Future.delayed(const Duration(milliseconds: 100));
+
+        bloc.add(const DeleteEntry('e1'));
+        await Future.delayed(const Duration(milliseconds: 100));
+
+        // Stale snapshot generated before the delete arrives late.
+        controller.add([e1, e2]);
+        await Future.delayed(const Duration(milliseconds: 100));
+        await controller.close();
+      },
+      verify: (bloc) {
+        expect(
+          bloc.state.entries.map((e) => e.id),
+          ['e2'],
+          reason: 'stale emits must not resurrect deleted entries (#205)',
+        );
+      },
+    );
+  });
+
+  group('todayCategoryCounts (#154)', () {
+    late MockJournalRepository mockRepository;
+
+    final today = DateTime.now();
+    final todayStr =
+        '${today.year}-${today.month.toString().padLeft(2, '0')}-${today.day.toString().padLeft(2, '0')}';
+
+    setUp(() {
+      mockRepository = MockJournalRepository();
+    });
+
+    test('derived from monthCategoryMarkers when constructed directly', () {
+      final state = JournalState(
+        monthCategoryMarkers: {
+          todayStr: {'positive': 2, 'gratitude': 1},
+        },
+      );
+      expect(state.todayCategoryCounts, {'positive': 2, 'gratitude': 1});
+      expect(state.journaledToday, true);
+    });
+
+    blocTest<JournalBloc, JournalState>(
+      'refreshed when SelectDate loads the month containing today',
+      setUp: () {
+        when(
+          () => mockRepository.watchCategoryEntries(any()),
+        ).thenAnswer((_) => const Stream.empty());
+        when(
+          () => mockRepository.getMonthCategoryMarkers(any(), any()),
+        ).thenAnswer(
+          (_) async => {
+            todayStr: {'positive': 1},
+          },
+        );
+        when(() => mockRepository.getStreakData()).thenAnswer(
+          (_) async => const StreakData(
+            currentStreak: 1,
+            longestStreak: 1,
+            lastJournalDate: null,
+          ),
+        );
+      },
+      build: () => JournalBloc(repository: mockRepository),
+      act: (bloc) => bloc.add(SelectDate(today)),
+      verify: (bloc) {
+        expect(bloc.state.todayCategoryCounts, {'positive': 1});
+        expect(bloc.state.journaledToday, true);
+      },
+    );
+
+    blocTest<JournalBloc, JournalState>(
+      'preserved when LoadMonthMarkers swaps to a different month',
+      setUp: () {
+        when(() => mockRepository.getMonthCategoryMarkers(2025, 1)).thenAnswer(
+          (_) async => {
+            '2025-01-05': {'beauty': 1},
+          },
+        );
+      },
+      build: () => JournalBloc(repository: mockRepository),
+      seed: () => JournalState(
+        monthCategoryMarkers: {
+          todayStr: {'positive': 1},
+        },
+      ),
+      act: (bloc) => bloc.add(const LoadMonthMarkers(year: 2025, month: 1)),
+      verify: (bloc) {
+        expect(bloc.state.monthCategoryMarkers, {
+          '2025-01-05': {'beauty': 1},
+        });
+        expect(
+          bloc.state.todayCategoryCounts,
+          {'positive': 1},
+          reason: 'today counts must survive month navigation (#154)',
+        );
+        expect(bloc.state.journaledToday, true);
+      },
+    );
+
+    test('counts dated before today read as empty (midnight rollover)', () {
+      final state = JournalState(
+        todayCategoryCounts: const {'positive': 2},
+        todayCountsDate: '2020-01-01',
+      );
+      expect(state.todayCategoryCounts, isEmpty);
+      expect(state.journaledToday, false);
+    });
+
+    blocTest<JournalBloc, JournalState>(
+      'optimistic AddEntry preserves today counts when markers hold '
+      'another month',
+      build: () => JournalBloc(repository: repository),
+      // Calendar was swiped to another month: marker map is NOT today's
+      // month, but today already has a gratitude entry.
+      seed: () => JournalState(
+        selectedDate: today,
+        monthCategoryMarkers: {
+          '2020-01-05': {'beauty': 1},
+        },
+        todayCategoryCounts: const {'gratitude': 1},
+      ),
+      act: (bloc) async {
+        bloc.add(const AddEntry(categoryId: 'positive', text: 'new today'));
+        await Future.delayed(const Duration(milliseconds: 200));
+      },
+      verify: (bloc) {
+        expect(bloc.state.todayCategoryCounts['positive'], 1);
+        expect(
+          bloc.state.todayCategoryCounts['gratitude'],
+          1,
+          reason: 'must not re-derive from the stale other-month map',
+        );
+      },
+    );
+
+    blocTest<JournalBloc, JournalState>(
+      'optimistic DeleteEntry decrements today counts without the '
+      'current-month marker map',
+      build: () => JournalBloc(repository: repository),
+      setUp: () async {
+        await repository.addCategoryEntry(todayStr, 'positive', 'kill me');
+      },
+      seed: () => JournalState(
+        selectedDate: today,
+        monthCategoryMarkers: {
+          '2020-01-05': {'beauty': 1},
+        },
+        todayCategoryCounts: const {'positive': 1, 'gratitude': 1},
+      ),
+      act: (bloc) async {
+        // Load entries so the bloc knows the entry id, then delete it.
+        bloc.add(const LoadEntries());
+        await Future.delayed(const Duration(milliseconds: 200));
+        bloc.add(DeleteEntry(bloc.state.entries.first.id));
+        await Future.delayed(const Duration(milliseconds: 200));
+      },
+      verify: (bloc) {
+        expect(bloc.state.todayCategoryCounts.containsKey('positive'), false);
+        expect(
+          bloc.state.todayCategoryCounts['gratitude'],
+          1,
+          reason: 'unrelated category must survive the delete',
+        );
+        expect(bloc.state.journaledToday, true);
+      },
+    );
+
+    blocTest<JournalBloc, JournalState>(
+      'updated by optimistic AddEntry for today',
+      build: () => JournalBloc(repository: repository),
+      seed: () => JournalState(selectedDate: today),
+      act: (bloc) async {
+        bloc.add(SelectDate(today));
+        await Future.delayed(const Duration(milliseconds: 200));
+        bloc.add(const AddEntry(categoryId: 'positive', text: 'today entry'));
+        await Future.delayed(const Duration(milliseconds: 200));
+      },
+      verify: (bloc) {
+        expect(bloc.state.todayCategoryCounts['positive'], 1);
+        expect(bloc.state.journaledToday, true);
+      },
+    );
+  });
 }

--- a/test/widgets/home_screen_test.dart
+++ b/test/widgets/home_screen_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:intl/intl.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:dytty/data/models/category_config.dart';
 import 'package:dytty/data/models/category_entry.dart';
 import 'package:dytty/features/auth/bloc/auth_bloc.dart';
@@ -79,20 +80,7 @@ void main() {
         const HomeScreen(),
         journalState: JournalState(
           status: JournalStatus.loaded,
-          entries: [
-            CategoryEntry(
-              id: 'e1',
-              categoryId: 'positive',
-              text: 'Good day',
-              createdAt: DateTime.now(),
-            ),
-            CategoryEntry(
-              id: 'e2',
-              categoryId: 'gratitude',
-              text: 'Thankful',
-              createdAt: DateTime.now(),
-            ),
-          ],
+          todayCategoryCounts: const {'positive': 1, 'gratitude': 1},
         ),
         categoryState: CategoryState(
           categories: CategoryConfig.defaults,
@@ -104,6 +92,92 @@ void main() {
       robot = HomeScreenRobot(tester);
       // 2 categories filled out of 5 defaults
       robot.expectProgressVisible(2, 5);
+    });
+
+    testWidgets('progress card shows today counts when a past date is '
+        'selected (#154)', (tester) async {
+      final pastDate = DateTime.now().subtract(const Duration(days: 10));
+      await tester.pumpApp(
+        const HomeScreen(),
+        journalState: JournalState(
+          status: JournalStatus.loaded,
+          selectedDate: pastDate,
+          // Selected (past) date has a single entry loaded...
+          entries: [
+            CategoryEntry(
+              id: 'e1',
+              categoryId: 'positive',
+              text: 'Old entry',
+              createdAt: pastDate,
+            ),
+          ],
+          // ...but today has 3 filled categories.
+          todayCategoryCounts: const {
+            'positive': 1,
+            'gratitude': 2,
+            'beauty': 1,
+          },
+        ),
+        categoryState: CategoryState(
+          categories: CategoryConfig.defaults,
+          loaded: true,
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      robot = HomeScreenRobot(tester);
+      // Dashboard reflects today (3/5), not the selected date (1/5).
+      robot.expectProgressVisible(3, 5);
+      expect(find.text("Today's Progress"), findsOneWidget);
+    });
+
+    testWidgets('shows error banner with retry when load failed (#170)', (
+      tester,
+    ) async {
+      await tester.pumpApp(
+        const HomeScreen(),
+        journalState: JournalState(
+          status: JournalStatus.loaded,
+          error: 'FAILED_PRECONDITION: index missing',
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(find.textContaining("Couldn't load"), findsOneWidget);
+      expect(find.text('Retry'), findsOneWidget);
+    });
+
+    testWidgets('tapping retry dispatches SelectDate for the selected date', (
+      tester,
+    ) async {
+      final selected = DateTime(2026, 6, 1);
+      final journalBloc = MockJournalBloc();
+
+      await tester.pumpApp(
+        const HomeScreen(),
+        journalBloc: journalBloc,
+        journalState: JournalState(
+          status: JournalStatus.loaded,
+          selectedDate: selected,
+          error: 'network down',
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      await tester.tap(find.text('Retry'));
+      await tester.pump();
+
+      verify(() => journalBloc.add(SelectDate(selected))).called(1);
+    });
+
+    testWidgets('no error banner when error is null', (tester) async {
+      await tester.pumpApp(
+        const HomeScreen(),
+        journalState: JournalState(status: JournalStatus.loaded),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(find.text('Retry'), findsNothing);
     });
 
     testWidgets('mic FAB is present', (tester) async {
@@ -170,26 +244,11 @@ void main() {
         const HomeScreen(),
         journalState: JournalState(
           status: JournalStatus.loaded,
-          entries: [
-            CategoryEntry(
-              id: 'e1',
-              categoryId: 'positive',
-              text: 'Good',
-              createdAt: DateTime.now(),
-            ),
-            CategoryEntry(
-              id: 'e2',
-              categoryId: 'gratitude',
-              text: 'Thanks',
-              createdAt: DateTime.now(),
-            ),
-            CategoryEntry(
-              id: 'e3',
-              categoryId: 'beauty',
-              text: 'Sunset',
-              createdAt: DateTime.now(),
-            ),
-          ],
+          todayCategoryCounts: const {
+            'positive': 1,
+            'gratitude': 1,
+            'beauty': 1,
+          },
         ),
         categoryState: CategoryState(
           categories: CategoryConfig.defaults,
@@ -207,38 +266,13 @@ void main() {
         const HomeScreen(),
         journalState: JournalState(
           status: JournalStatus.loaded,
-          entries: [
-            CategoryEntry(
-              id: 'e1',
-              categoryId: 'positive',
-              text: 'Good',
-              createdAt: DateTime.now(),
-            ),
-            CategoryEntry(
-              id: 'e2',
-              categoryId: 'negative',
-              text: 'Bad',
-              createdAt: DateTime.now(),
-            ),
-            CategoryEntry(
-              id: 'e3',
-              categoryId: 'gratitude',
-              text: 'Thanks',
-              createdAt: DateTime.now(),
-            ),
-            CategoryEntry(
-              id: 'e4',
-              categoryId: 'beauty',
-              text: 'Sunset',
-              createdAt: DateTime.now(),
-            ),
-            CategoryEntry(
-              id: 'e5',
-              categoryId: 'identity',
-              text: 'Growth',
-              createdAt: DateTime.now(),
-            ),
-          ],
+          todayCategoryCounts: const {
+            'positive': 1,
+            'negative': 1,
+            'gratitude': 1,
+            'beauty': 1,
+            'identity': 1,
+          },
         ),
         categoryState: CategoryState(
           categories: CategoryConfig.defaults,
@@ -335,38 +369,13 @@ void main() {
         const HomeScreen(),
         journalState: JournalState(
           status: JournalStatus.loaded,
-          entries: [
-            CategoryEntry(
-              id: 'e1',
-              categoryId: 'positive',
-              text: 'Good',
-              createdAt: DateTime.now(),
-            ),
-            CategoryEntry(
-              id: 'e2',
-              categoryId: 'negative',
-              text: 'Bad',
-              createdAt: DateTime.now(),
-            ),
-            CategoryEntry(
-              id: 'e3',
-              categoryId: 'gratitude',
-              text: 'Thanks',
-              createdAt: DateTime.now(),
-            ),
-            CategoryEntry(
-              id: 'e4',
-              categoryId: 'beauty',
-              text: 'Sunset',
-              createdAt: DateTime.now(),
-            ),
-            CategoryEntry(
-              id: 'e5',
-              categoryId: 'identity',
-              text: 'Growth',
-              createdAt: DateTime.now(),
-            ),
-          ],
+          todayCategoryCounts: const {
+            'positive': 1,
+            'negative': 1,
+            'gratitude': 1,
+            'beauty': 1,
+            'identity': 1,
+          },
         ),
         categoryState: CategoryState(
           categories: CategoryConfig.defaults,
@@ -385,14 +394,7 @@ void main() {
         const HomeScreen(),
         journalState: JournalState(
           status: JournalStatus.loaded,
-          entries: [
-            CategoryEntry(
-              id: 'e1',
-              categoryId: 'positive',
-              text: 'Good',
-              createdAt: DateTime.now(),
-            ),
-          ],
+          todayCategoryCounts: const {'positive': 1},
         ),
         categoryState: CategoryState(
           categories: CategoryConfig.defaults,
@@ -412,32 +414,12 @@ void main() {
         const HomeScreen(),
         journalState: JournalState(
           status: JournalStatus.loaded,
-          entries: [
-            CategoryEntry(
-              id: 'e1',
-              categoryId: 'positive',
-              text: 'Good',
-              createdAt: DateTime.now(),
-            ),
-            CategoryEntry(
-              id: 'e2',
-              categoryId: 'negative',
-              text: 'Bad',
-              createdAt: DateTime.now(),
-            ),
-            CategoryEntry(
-              id: 'e3',
-              categoryId: 'gratitude',
-              text: 'Thanks',
-              createdAt: DateTime.now(),
-            ),
-            CategoryEntry(
-              id: 'e4',
-              categoryId: 'beauty',
-              text: 'Sunset',
-              createdAt: DateTime.now(),
-            ),
-          ],
+          todayCategoryCounts: const {
+            'positive': 1,
+            'negative': 1,
+            'gratitude': 1,
+            'beauty': 1,
+          },
         ),
         categoryState: CategoryState(
           categories: CategoryConfig.defaults,


### PR DESCRIPTION
Workflow sync after the #209 promotion — brings the state-refresh work (incl. home_screen.dart changes) under the radial branch before #190/#158 implementation. Clean merge, full suite green.

Refs #190, #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)