### PR TITLE
feat: Save as-is + voice note handling preference (#32)

### DIFF
--- a/lib/core/constants/voice_note_handling.dart
+++ b/lib/core/constants/voice_note_handling.dart
@@ -1,0 +1,15 @@
+/// How a finished voice-note recording proceeds (#32): pause for
+/// transcript review, summarize immediately, or keep the raw transcript
+/// immediately. Shared by VoiceNoteBloc (routing), SettingsCubit
+/// (persistence) and the recording sheet (wiring).
+enum VoiceNoteHandling {
+  ask,
+  summarize,
+  raw;
+
+  /// Value stored in the user settings profile document.
+  String get storageValue => name;
+
+  static VoiceNoteHandling fromStorage(String? value) =>
+      VoiceNoteHandling.values.asNameMap()[value] ?? VoiceNoteHandling.ask;
+}

--- a/lib/data/repositories/journal_repository.dart
+++ b/lib/data/repositories/journal_repository.dart
@@ -353,10 +353,13 @@ class JournalRepository {
     final snapshot = await profileDoc.get();
 
     if (!snapshot.exists) {
-      return {'hideEntries': false};
+      return {'hideEntries': false, 'voiceNoteHandling': 'ask'};
     }
     final data = snapshot.data() ?? {};
-    return {'hideEntries': data['hideEntries'] ?? false};
+    return {
+      'hideEntries': data['hideEntries'] ?? false,
+      'voiceNoteHandling': data['voiceNoteHandling'] ?? 'ask',
+    };
   }
 
   /// Updates user settings in profile doc.

--- a/lib/features/settings/cubit/settings_cubit.dart
+++ b/lib/features/settings/cubit/settings_cubit.dart
@@ -1,11 +1,16 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:dytty/core/constants/voice_note_handling.dart';
 import 'package:dytty/data/repositories/journal_repository.dart';
 import 'package:dytty/services/notification/notification_service.dart';
 
+export 'package:dytty/core/constants/voice_note_handling.dart'
+    show VoiceNoteHandling;
+
 class SettingsState extends Equatable {
   final bool hideEntries;
+  final VoiceNoteHandling voiceNoteHandling;
   final bool loaded;
   final bool reminderEnabled;
   final TimeOfDay reminderTime;
@@ -14,6 +19,7 @@ class SettingsState extends Equatable {
 
   const SettingsState({
     this.hideEntries = false,
+    this.voiceNoteHandling = VoiceNoteHandling.ask,
     this.loaded = false,
     this.reminderEnabled = false,
     this.reminderTime = const TimeOfDay(
@@ -29,6 +35,7 @@ class SettingsState extends Equatable {
 
   SettingsState copyWith({
     bool? hideEntries,
+    VoiceNoteHandling? voiceNoteHandling,
     bool? loaded,
     bool? reminderEnabled,
     TimeOfDay? reminderTime,
@@ -37,6 +44,7 @@ class SettingsState extends Equatable {
   }) {
     return SettingsState(
       hideEntries: hideEntries ?? this.hideEntries,
+      voiceNoteHandling: voiceNoteHandling ?? this.voiceNoteHandling,
       loaded: loaded ?? this.loaded,
       reminderEnabled: reminderEnabled ?? this.reminderEnabled,
       reminderTime: reminderTime ?? this.reminderTime,
@@ -48,6 +56,7 @@ class SettingsState extends Equatable {
   @override
   List<Object?> get props => [
     hideEntries,
+    voiceNoteHandling,
     loaded,
     reminderEnabled,
     reminderTime,
@@ -73,6 +82,9 @@ class SettingsCubit extends Cubit<SettingsState> {
       emit(
         SettingsState(
           hideEntries: settings['hideEntries'] as bool? ?? false,
+          voiceNoteHandling: VoiceNoteHandling.fromStorage(
+            settings['voiceNoteHandling'] as String?,
+          ),
           loaded: true,
           reminderEnabled: _notificationService.isReminderEnabled,
           reminderTime: TimeOfDay(
@@ -102,6 +114,21 @@ class SettingsCubit extends Cubit<SettingsState> {
           ),
         ),
       );
+    }
+  }
+
+  /// Persists the voice-note handling preference (#32), reverting on
+  /// repository failure -- same optimistic pattern as toggleHideEntries.
+  Future<void> setVoiceNoteHandling(VoiceNoteHandling handling) async {
+    final previous = state.voiceNoteHandling;
+    if (previous == handling) return;
+    emit(state.copyWith(voiceNoteHandling: handling));
+    try {
+      await _repository.updateUserSettings({
+        'voiceNoteHandling': handling.storageValue,
+      });
+    } catch (_) {
+      emit(state.copyWith(voiceNoteHandling: previous));
     }
   }
 

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -180,6 +180,66 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
           const SizedBox(height: 20),
 
+          // Voice notes section (#32) — what happens after a recording
+          // finishes: pause for transcript review, or skip straight ahead.
+          _SectionLabel(label: 'Voice notes'),
+          const SizedBox(height: 8),
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 4),
+              child: Column(
+                children: [
+                  _ThemeTile(
+                    icon: Icons.help_outline_rounded,
+                    label: 'Ask each time',
+                    selected:
+                        settingsState.voiceNoteHandling ==
+                        VoiceNoteHandling.ask,
+                    onTap: () => context
+                        .read<SettingsCubit>()
+                        .setVoiceNoteHandling(VoiceNoteHandling.ask),
+                  ),
+                  Divider(
+                    height: 1,
+                    indent: 56,
+                    color: theme.colorScheme.outlineVariant.withValues(
+                      alpha: 0.3,
+                    ),
+                  ),
+                  _ThemeTile(
+                    icon: Icons.auto_awesome_rounded,
+                    label: 'Summarize automatically',
+                    selected:
+                        settingsState.voiceNoteHandling ==
+                        VoiceNoteHandling.summarize,
+                    onTap: () => context
+                        .read<SettingsCubit>()
+                        .setVoiceNoteHandling(VoiceNoteHandling.summarize),
+                  ),
+                  Divider(
+                    height: 1,
+                    indent: 56,
+                    color: theme.colorScheme.outlineVariant.withValues(
+                      alpha: 0.3,
+                    ),
+                  ),
+                  _ThemeTile(
+                    icon: Icons.notes_rounded,
+                    label: 'Keep raw transcript',
+                    selected:
+                        settingsState.voiceNoteHandling ==
+                        VoiceNoteHandling.raw,
+                    onTap: () => context
+                        .read<SettingsCubit>()
+                        .setVoiceNoteHandling(VoiceNoteHandling.raw),
+                  ),
+                ],
+              ),
+            ),
+          ),
+
+          const SizedBox(height: 20),
+
           // Reminders section
           _SectionLabel(label: 'Reminders'),
           const SizedBox(height: 8),

--- a/lib/features/voice_note/bloc/voice_note_bloc.dart
+++ b/lib/features/voice_note/bloc/voice_note_bloc.dart
@@ -2,8 +2,12 @@ import 'dart:async';
 
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:dytty/core/constants/voice_note_handling.dart';
 import 'package:dytty/services/llm/llm_service.dart';
 import 'package:dytty/services/speech/speech_service.dart';
+
+export 'package:dytty/core/constants/voice_note_handling.dart'
+    show VoiceNoteHandling;
 
 // --- Events ---
 
@@ -161,10 +165,6 @@ class VoiceNoteState extends Equatable {
 }
 
 // --- Bloc ---
-
-/// How a finished recording proceeds (#32): pause for transcript review,
-/// summarize immediately, or keep the raw transcript immediately.
-enum VoiceNoteHandling { ask, summarize, raw }
 
 class VoiceNoteBloc extends Bloc<VoiceNoteEvent, VoiceNoteState> {
   final SpeechService _speechService;

--- a/lib/features/voice_note/bloc/voice_note_bloc.dart
+++ b/lib/features/voice_note/bloc/voice_note_bloc.dart
@@ -326,21 +326,16 @@ class VoiceNoteBloc extends Bloc<VoiceNoteEvent, VoiceNoteState> {
           confidence: result.confidence,
         ),
       );
-    } on TimeoutException {
-      // LLM timed out — let user pick category manually
+    } catch (_) {
+      // Any LLM unavailability — timeout, server overload (Gemini 500),
+      // network — degrades to raw review: the user's words are never
+      // hostage to the model, they just pick the category manually.
       emit(
         VoiceNoteState(
           status: VoiceNoteStatus.reviewing,
           transcript: state.transcript,
           originalTranscript: state.transcript,
           summary: state.transcript,
-        ),
-      );
-    } catch (e) {
-      emit(
-        state.copyWith(
-          status: VoiceNoteStatus.error,
-          error: 'Failed to categorize: $e',
         ),
       );
     }

--- a/lib/features/voice_note/bloc/voice_note_bloc.dart
+++ b/lib/features/voice_note/bloc/voice_note_bloc.dart
@@ -62,6 +62,12 @@ class RequestCategorization extends VoiceNoteEvent {
   const RequestCategorization();
 }
 
+/// Save-as-is path (#32): advance to reviewing with the raw transcript
+/// as the entry text, skipping the LLM entirely.
+class SkipCategorization extends VoiceNoteEvent {
+  const SkipCategorization();
+}
+
 class UpdateTranscript extends VoiceNoteEvent {
   final String text;
 
@@ -156,24 +162,32 @@ class VoiceNoteState extends Equatable {
 
 // --- Bloc ---
 
+/// How a finished recording proceeds (#32): pause for transcript review,
+/// summarize immediately, or keep the raw transcript immediately.
+enum VoiceNoteHandling { ask, summarize, raw }
+
 class VoiceNoteBloc extends Bloc<VoiceNoteEvent, VoiceNoteState> {
   final SpeechService _speechService;
   final LlmService _llmService;
   final Duration _categorizationTimeout;
+  final VoiceNoteHandling _handling;
 
   VoiceNoteBloc({
     required SpeechService speechService,
     required LlmService llmService,
     Duration categorizationTimeout = const Duration(seconds: 10),
+    VoiceNoteHandling handling = VoiceNoteHandling.ask,
   }) : _speechService = speechService,
        _llmService = llmService,
        _categorizationTimeout = categorizationTimeout,
+       _handling = handling,
        super(const VoiceNoteState()) {
     on<InitializeSpeech>(_onInitializeSpeech);
     on<StartListening>(_onStartListening);
     on<StopListening>(_onStopListening);
     on<_SpeechResultReceived>(_onSpeechResultReceived);
     on<RequestCategorization>(_onRequestCategorization);
+    on<SkipCategorization>(_onSkipCategorization);
     on<CategorizeTranscript>(_onCategorizeTranscript);
     on<UpdateCategory>(_onUpdateCategory);
     on<UpdateText>(_onUpdateText);
@@ -228,7 +242,20 @@ class VoiceNoteBloc extends Bloc<VoiceNoteEvent, VoiceNoteState> {
   ) {
     emit(state.copyWith(transcript: event.text));
     if (event.isFinal && event.text.isNotEmpty) {
-      emit(state.copyWith(status: VoiceNoteStatus.transcriptReview));
+      _advancePastTranscript(emit);
+    }
+  }
+
+  /// Routes a finished transcript per the handling preference (#32):
+  /// ask pauses at transcriptReview; summarize/raw skip it.
+  void _advancePastTranscript(Emitter<VoiceNoteState> emit) {
+    switch (_handling) {
+      case VoiceNoteHandling.ask:
+        emit(state.copyWith(status: VoiceNoteStatus.transcriptReview));
+      case VoiceNoteHandling.summarize:
+        add(const CategorizeTranscript());
+      case VoiceNoteHandling.raw:
+        add(const SkipCategorization());
     }
   }
 
@@ -238,7 +265,7 @@ class VoiceNoteBloc extends Bloc<VoiceNoteEvent, VoiceNoteState> {
   ) async {
     await _speechService.stopListening();
     if (state.transcript.isNotEmpty) {
-      emit(state.copyWith(status: VoiceNoteStatus.transcriptReview));
+      _advancePastTranscript(emit);
     } else {
       emit(state.copyWith(status: VoiceNoteStatus.ready));
     }
@@ -249,6 +276,20 @@ class VoiceNoteBloc extends Bloc<VoiceNoteEvent, VoiceNoteState> {
     Emitter<VoiceNoteState> emit,
   ) {
     add(const CategorizeTranscript());
+  }
+
+  /// Save-as-is (#32): reviewing with the raw transcript as the entry
+  /// text and no suggested category — the user picks one manually.
+  void _onSkipCategorization(
+    SkipCategorization event,
+    Emitter<VoiceNoteState> emit,
+  ) {
+    emit(
+      state.copyWith(
+        status: VoiceNoteStatus.reviewing,
+        summary: state.transcript,
+      ),
+    );
   }
 
   Future<void> _onCategorizeTranscript(

--- a/lib/features/voice_note/bloc/voice_note_bloc.dart
+++ b/lib/features/voice_note/bloc/voice_note_bloc.dart
@@ -248,14 +248,22 @@ class VoiceNoteBloc extends Bloc<VoiceNoteEvent, VoiceNoteState> {
 
   /// Routes a finished transcript per the handling preference (#32):
   /// ask pauses at transcriptReview; summarize/raw skip it.
+  ///
+  /// Called from both the final speech result and StopListening — on
+  /// Android the plugin flushes a final result while stopListening is in
+  /// flight, so both paths fire back to back. The status guard plus the
+  /// synchronous emits below keep that second call a no-op (one LLM call,
+  /// no late state clobber).
   void _advancePastTranscript(Emitter<VoiceNoteState> emit) {
+    if (state.status != VoiceNoteStatus.listening) return;
     switch (_handling) {
       case VoiceNoteHandling.ask:
         emit(state.copyWith(status: VoiceNoteStatus.transcriptReview));
       case VoiceNoteHandling.summarize:
+        emit(state.copyWith(status: VoiceNoteStatus.processing));
         add(const CategorizeTranscript());
       case VoiceNoteHandling.raw:
-        add(const SkipCategorization());
+        emit(_skippedCategorizationState());
     }
   }
 
@@ -284,11 +292,16 @@ class VoiceNoteBloc extends Bloc<VoiceNoteEvent, VoiceNoteState> {
     SkipCategorization event,
     Emitter<VoiceNoteState> emit,
   ) {
-    emit(
-      state.copyWith(
-        status: VoiceNoteStatus.reviewing,
-        summary: state.transcript,
-      ),
+    emit(_skippedCategorizationState());
+  }
+
+  /// originalTranscript must be recorded even without an LLM pass —
+  /// Re-summarize in reviewing feeds it to reconcileSummary.
+  VoiceNoteState _skippedCategorizationState() {
+    return state.copyWith(
+      status: VoiceNoteStatus.reviewing,
+      originalTranscript: state.transcript,
+      summary: state.transcript,
     );
   }
 

--- a/lib/features/voice_note/widgets/voice_recording_sheet.dart
+++ b/lib/features/voice_note/widgets/voice_recording_sheet.dart
@@ -297,13 +297,13 @@ class _TranscriptReviewViewState extends State<_TranscriptReviewView> {
             ),
             const SizedBox(width: 12),
             // Save-as-is (#32): keep the raw transcript, skip the LLM.
+            // Outlined per SPEC-32 — Summarize stays the filled primary.
             Expanded(
-              child: FilledButton.tonalIcon(
+              child: OutlinedButton(
                 onPressed: () {
                   context.read<VoiceNoteBloc>().add(const SkipCategorization());
                 },
-                icon: const Icon(Icons.save_alt_rounded),
-                label: const Text('Save as-is'),
+                child: const Text('Save as-is'),
               ),
             ),
             const SizedBox(width: 12),

--- a/lib/features/voice_note/widgets/voice_recording_sheet.dart
+++ b/lib/features/voice_note/widgets/voice_recording_sheet.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:dytty/features/settings/cubit/category_cubit.dart';
+import 'package:dytty/features/settings/cubit/settings_cubit.dart';
 import 'package:dytty/features/voice_note/bloc/voice_note_bloc.dart';
 import 'package:dytty/features/voice_note/voice_note_result.dart';
 import 'package:dytty/services/llm/llm_service.dart';
@@ -22,6 +23,7 @@ Future<VoiceNoteResult?> showVoiceRecordingSheet(BuildContext context) {
         create: (_) => VoiceNoteBloc(
           speechService: context.read<SpeechService>(),
           llmService: context.read<LlmService>(),
+          handling: context.read<SettingsCubit>().state.voiceNoteHandling,
         )..add(const InitializeSpeech()),
         child: _VoiceRecordingSheetBody(
           categories: context.read<CategoryCubit>().state.activeCategories,
@@ -291,6 +293,17 @@ class _TranscriptReviewViewState extends State<_TranscriptReviewView> {
               child: OutlinedButton(
                 onPressed: () => Navigator.pop(context),
                 child: const Text('Discard'),
+              ),
+            ),
+            const SizedBox(width: 12),
+            // Save-as-is (#32): keep the raw transcript, skip the LLM.
+            Expanded(
+              child: FilledButton.tonalIcon(
+                onPressed: () {
+                  context.read<VoiceNoteBloc>().add(const SkipCategorization());
+                },
+                icon: const Icon(Icons.save_alt_rounded),
+                label: const Text('Save as-is'),
               ),
             ),
             const SizedBox(width: 12),

--- a/test/data/repositories/journal_repository_test.dart
+++ b/test/data/repositories/journal_repository_test.dart
@@ -336,6 +336,19 @@ void main() {
         final settings = await repository.getUserSettings();
         expect(settings['hideEntries'], true);
       });
+
+      test('voiceNoteHandling defaults to ask (#32)', () async {
+        final settings = await repository.getUserSettings();
+        expect(settings['voiceNoteHandling'], 'ask');
+      });
+
+      test('persists and retrieves voiceNoteHandling (#32)', () async {
+        await repository.ensureUserProfile('Test', 'test@test.com');
+        await repository.updateUserSettings({'voiceNoteHandling': 'raw'});
+
+        final settings = await repository.getUserSettings();
+        expect(settings['voiceNoteHandling'], 'raw');
+      });
     });
 
     group('getCategoryEntriesForDateRange', () {

--- a/test/features/settings/settings_cubit_test.dart
+++ b/test/features/settings/settings_cubit_test.dart
@@ -439,6 +439,17 @@ void main() {
       ],
     );
 
+    blocTest<SettingsCubit, SettingsState>(
+      'setVoiceNoteHandling is a no-op when value is unchanged',
+      build: () => SettingsCubit(
+        repository: repository,
+        notificationService: notificationService,
+      ),
+      seed: () => const SettingsState(loaded: true),
+      act: (cubit) => cubit.setVoiceNoteHandling(VoiceNoteHandling.ask),
+      expect: () => <SettingsState>[],
+    );
+
     test('initial state defaults to ask', () {
       final cubit = SettingsCubit(
         repository: repository,
@@ -473,6 +484,33 @@ void main() {
         isA<SettingsState>()
             .having((s) => s.loaded, 'loaded', true)
             .having((s) => s.hideEntries, 'hideEntries', false),
+      ],
+    );
+
+    blocTest<SettingsCubit, SettingsState>(
+      'setVoiceNoteHandling reverts on repository error',
+      setUp: () {
+        when(
+          () => mockRepository.updateUserSettings(any()),
+        ).thenThrow(Exception('Write failed'));
+      },
+      build: () => SettingsCubit(
+        repository: mockRepository,
+        notificationService: notificationService,
+      ),
+      seed: () => const SettingsState(loaded: true),
+      act: (cubit) => cubit.setVoiceNoteHandling(VoiceNoteHandling.raw),
+      expect: () => [
+        isA<SettingsState>().having(
+          (s) => s.voiceNoteHandling,
+          'voiceNoteHandling',
+          VoiceNoteHandling.raw,
+        ),
+        isA<SettingsState>().having(
+          (s) => s.voiceNoteHandling,
+          'voiceNoteHandling',
+          VoiceNoteHandling.ask,
+        ),
       ],
     );
 

--- a/test/features/settings/settings_cubit_test.dart
+++ b/test/features/settings/settings_cubit_test.dart
@@ -395,6 +395,59 @@ void main() {
     );
   });
 
+  group('voiceNoteHandling preference (#32)', () {
+    blocTest<SettingsCubit, SettingsState>(
+      'setVoiceNoteHandling emits and persists',
+      build: () => SettingsCubit(
+        repository: repository,
+        notificationService: notificationService,
+      ),
+      seed: () => const SettingsState(loaded: true),
+      act: (cubit) => cubit.setVoiceNoteHandling(VoiceNoteHandling.raw),
+      expect: () => [
+        isA<SettingsState>().having(
+          (s) => s.voiceNoteHandling,
+          'voiceNoteHandling',
+          VoiceNoteHandling.raw,
+        ),
+      ],
+      verify: (_) async {
+        final settings = await repository.getUserSettings();
+        expect(settings['voiceNoteHandling'], 'raw');
+      },
+    );
+
+    blocTest<SettingsCubit, SettingsState>(
+      'loadSettings reads persisted voiceNoteHandling',
+      setUp: () async {
+        await repository.ensureUserProfile('Test', 'test@test.com');
+        await repository.updateUserSettings({'voiceNoteHandling': 'summarize'});
+      },
+      build: () => SettingsCubit(
+        repository: repository,
+        notificationService: notificationService,
+      ),
+      act: (cubit) => cubit.loadSettings(),
+      expect: () => [
+        isA<SettingsState>()
+            .having(
+              (s) => s.voiceNoteHandling,
+              'voiceNoteHandling',
+              VoiceNoteHandling.summarize,
+            )
+            .having((s) => s.loaded, 'loaded', true),
+      ],
+    );
+
+    test('initial state defaults to ask', () {
+      final cubit = SettingsCubit(
+        repository: repository,
+        notificationService: notificationService,
+      );
+      expect(cubit.state.voiceNoteHandling, VoiceNoteHandling.ask);
+    });
+  });
+
   group('SettingsCubit error paths', () {
     late MockJournalRepository mockRepository;
     late FakeNotificationService notificationService;

--- a/test/features/voice_note/voice_note_bloc_test.dart
+++ b/test/features/voice_note/voice_note_bloc_test.dart
@@ -601,6 +601,95 @@ void main() {
     });
   });
 
+  group('save-as-is and handling preference (#32)', () {
+    SpeechRecognitionResult finalResult(String words) =>
+        SpeechRecognitionResult([
+          SpeechRecognitionWords(words, null, 0.95),
+        ], true);
+
+    blocTest<VoiceNoteBloc, VoiceNoteState>(
+      'SkipCategorization moves to reviewing with raw transcript, no LLM',
+      build: () =>
+          VoiceNoteBloc(speechService: speechService, llmService: llmService),
+      seed: () => const VoiceNoteState(
+        status: VoiceNoteStatus.transcriptReview,
+        transcript: 'today I fixed the radial menu',
+      ),
+      act: (bloc) => bloc.add(const SkipCategorization()),
+      verify: (bloc) {
+        expect(bloc.state.status, VoiceNoteStatus.reviewing);
+        expect(bloc.state.summary, 'today I fixed the radial menu');
+        expect(bloc.state.suggestedCategory, isNull);
+        expect(llmService.callCount, 0, reason: 'save-as-is skips the LLM');
+      },
+    );
+
+    blocTest<VoiceNoteBloc, VoiceNoteState>(
+      'handling=summarize: final result goes straight to processing',
+      build: () => VoiceNoteBloc(
+        speechService: speechService,
+        llmService: llmService,
+        handling: VoiceNoteHandling.summarize,
+      ),
+      act: (bloc) async {
+        bloc.add(const InitializeSpeech());
+        await Future.delayed(const Duration(milliseconds: 50));
+        bloc.add(const StartListening());
+        await Future.delayed(const Duration(milliseconds: 50));
+        speechService.lastOnResult!(finalResult('skip the review step'));
+        await Future.delayed(const Duration(milliseconds: 100));
+      },
+      verify: (bloc) {
+        // LLM ran (FakeLlmService resolves) — landed in reviewing with a
+        // suggestion, never pausing at transcriptReview.
+        expect(bloc.state.status, VoiceNoteStatus.reviewing);
+        expect(bloc.state.suggestedCategory, isNotNull);
+        expect(llmService.callCount, greaterThan(0));
+      },
+    );
+
+    blocTest<VoiceNoteBloc, VoiceNoteState>(
+      'handling=raw: final result lands in reviewing with raw summary',
+      build: () => VoiceNoteBloc(
+        speechService: speechService,
+        llmService: llmService,
+        handling: VoiceNoteHandling.raw,
+      ),
+      act: (bloc) async {
+        bloc.add(const InitializeSpeech());
+        await Future.delayed(const Duration(milliseconds: 50));
+        bloc.add(const StartListening());
+        await Future.delayed(const Duration(milliseconds: 50));
+        speechService.lastOnResult!(finalResult('keep me verbatim'));
+        await Future.delayed(const Duration(milliseconds: 100));
+      },
+      verify: (bloc) {
+        expect(bloc.state.status, VoiceNoteStatus.reviewing);
+        expect(bloc.state.summary, 'keep me verbatim');
+        expect(bloc.state.suggestedCategory, isNull);
+        expect(llmService.callCount, 0);
+      },
+    );
+
+    blocTest<VoiceNoteBloc, VoiceNoteState>(
+      'default handling=ask keeps the transcriptReview pause',
+      build: () =>
+          VoiceNoteBloc(speechService: speechService, llmService: llmService),
+      act: (bloc) async {
+        bloc.add(const InitializeSpeech());
+        await Future.delayed(const Duration(milliseconds: 50));
+        bloc.add(const StartListening());
+        await Future.delayed(const Duration(milliseconds: 50));
+        speechService.lastOnResult!(finalResult('ask me first'));
+        await Future.delayed(const Duration(milliseconds: 100));
+      },
+      verify: (bloc) {
+        expect(bloc.state.status, VoiceNoteStatus.transcriptReview);
+        expect(llmService.callCount, 0);
+      },
+    );
+  });
+
   group('VoiceNoteState', () {
     test('copyWith preserves values when no arguments given', () {
       const original = VoiceNoteState(

--- a/test/features/voice_note/voice_note_bloc_test.dart
+++ b/test/features/voice_note/voice_note_bloc_test.dart
@@ -672,6 +672,52 @@ void main() {
     );
 
     blocTest<VoiceNoteBloc, VoiceNoteState>(
+      'handling=summarize: Done-tap racing the final result fires one LLM '
+      'call',
+      build: () => VoiceNoteBloc(
+        speechService: speechService,
+        llmService: llmService,
+        handling: VoiceNoteHandling.summarize,
+      ),
+      act: (bloc) async {
+        bloc.add(const InitializeSpeech());
+        await Future.delayed(const Duration(milliseconds: 50));
+        bloc.add(const StartListening());
+        await Future.delayed(const Duration(milliseconds: 50));
+        // Android commonly flushes the final result while stopListening is
+        // in flight: both advance paths run back to back.
+        speechService.lastOnResult!(finalResult('said once'));
+        bloc.add(const StopListening());
+        await Future.delayed(const Duration(milliseconds: 100));
+      },
+      verify: (bloc) {
+        expect(bloc.state.status, VoiceNoteStatus.reviewing);
+        expect(
+          llmService.callCount,
+          1,
+          reason: 'duplicate advance must not double-call the LLM',
+        );
+      },
+    );
+
+    blocTest<VoiceNoteBloc, VoiceNoteState>(
+      'SkipCategorization records originalTranscript for re-summarize',
+      build: () =>
+          VoiceNoteBloc(speechService: speechService, llmService: llmService),
+      seed: () => const VoiceNoteState(
+        status: VoiceNoteStatus.transcriptReview,
+        transcript: 'edited before saving',
+        transcriptEdited: true,
+      ),
+      act: (bloc) => bloc.add(const SkipCategorization()),
+      verify: (bloc) {
+        // Re-summarize in reviewing calls reconcileSummary(originalTranscript,
+        // transcript) — save-as-is must not leave the original empty.
+        expect(bloc.state.originalTranscript, 'edited before saving');
+      },
+    );
+
+    blocTest<VoiceNoteBloc, VoiceNoteState>(
       'default handling=ask keeps the transcriptReview pause',
       build: () =>
           VoiceNoteBloc(speechService: speechService, llmService: llmService),

--- a/test/features/voice_note/voice_note_bloc_test.dart
+++ b/test/features/voice_note/voice_note_bloc_test.dart
@@ -441,7 +441,8 @@ void main() {
     );
 
     blocTest<VoiceNoteBloc, VoiceNoteState>(
-      'CategorizeTranscript emits error when LLM throws non-timeout exception',
+      'CategorizeTranscript falls back to raw review when the LLM throws '
+      '(owner-verify: Gemini 500 must not block the note)',
       build: () {
         final errorLlm = _ErrorLlmService();
         return VoiceNoteBloc(
@@ -461,9 +462,36 @@ void main() {
           VoiceNoteStatus.processing,
         ),
         isA<VoiceNoteState>()
-            .having((s) => s.status, 'status', VoiceNoteStatus.error)
-            .having((s) => s.error, 'error', contains('Failed to categorize')),
+            .having((s) => s.status, 'status', VoiceNoteStatus.reviewing)
+            .having((s) => s.summary, 'summary', 'Some journal text')
+            .having((s) => s.suggestedCategory, 'suggestedCategory', isNull),
       ],
+    );
+
+    blocTest<VoiceNoteBloc, VoiceNoteState>(
+      'handling=summarize with failing LLM still lands in reviewing with '
+      'the raw transcript',
+      build: () => VoiceNoteBloc(
+        speechService: speechService,
+        llmService: _ErrorLlmService(),
+        handling: VoiceNoteHandling.summarize,
+      ),
+      act: (bloc) async {
+        bloc.add(const InitializeSpeech());
+        await Future.delayed(const Duration(milliseconds: 50));
+        bloc.add(const StartListening());
+        await Future.delayed(const Duration(milliseconds: 50));
+        speechService.lastOnResult!(
+          SpeechRecognitionResult([
+            SpeechRecognitionWords('overloaded model words', null, 0.95),
+          ], true),
+        );
+        await Future.delayed(const Duration(milliseconds: 100));
+      },
+      verify: (bloc) {
+        expect(bloc.state.status, VoiceNoteStatus.reviewing);
+        expect(bloc.state.summary, 'overloaded model words');
+      },
     );
 
     blocTest<VoiceNoteBloc, VoiceNoteState>(

--- a/test/widgets/settings_developer_section_test.dart
+++ b/test/widgets/settings_developer_section_test.dart
@@ -69,11 +69,17 @@ void main() {
     testWidgets('shows minimal prompt toggle off by default', (tester) async {
       await tester.pumpWidget(buildSubject());
       await tester.pumpAndSettle();
-      await scrollToDeveloper(tester);
 
+      // Scroll to the tile itself — the lazy ListView only builds what is
+      // on screen, so stopping at the section label is not enough.
       final switchFinder = find.widgetWithText(
         SwitchListTile,
         'Minimal system prompt',
+      );
+      await tester.scrollUntilVisible(
+        switchFinder,
+        200,
+        scrollable: find.byType(Scrollable).first,
       );
       expect(switchFinder, findsOneWidget);
 
@@ -112,8 +118,12 @@ void main() {
 
       await tester.pumpWidget(buildSubject());
       await tester.pumpAndSettle();
-      await scrollToDeveloper(tester);
 
+      await tester.scrollUntilVisible(
+        find.textContaining('Active:'),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
       expect(find.textContaining('Active:'), findsOneWidget);
     });
 

--- a/test/widgets/settings_screen_test.dart
+++ b/test/widgets/settings_screen_test.dart
@@ -19,6 +19,10 @@ void main() {
 
   late SettingsScreenRobot robot;
 
+  setUpAll(() {
+    registerFallbackValue(VoiceNoteHandling.ask);
+  });
+
   setUp(() {
     Animate.restartOnHotReload = false;
   });
@@ -379,6 +383,59 @@ void main() {
       await tester.pump();
 
       verify(() => mockSettingsCubit.toggleReminder()).called(1);
+    });
+
+    testWidgets('shows voice note handling options (#32)', (tester) async {
+      await tester.pumpApp(const SettingsScreen());
+      await tester.pump(const Duration(seconds: 1));
+
+      robot = SettingsScreenRobot(tester);
+      await robot.scrollTo(find.text('Voice notes'));
+      expect(find.text('Ask each time'), findsOneWidget);
+      expect(find.text('Summarize automatically'), findsOneWidget);
+      expect(find.text('Keep raw transcript'), findsOneWidget);
+    });
+
+    testWidgets('marks persisted handling as selected (#32)', (tester) async {
+      await tester.pumpApp(
+        const SettingsScreen(),
+        settingsState: const SettingsState(
+          loaded: true,
+          voiceNoteHandling: VoiceNoteHandling.summarize,
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      robot = SettingsScreenRobot(tester);
+      await robot.scrollTo(find.text('Keep raw transcript'));
+      robot.expectThemeSelected('Summarize automatically');
+      robot.expectThemeNotSelected('Ask each time');
+      robot.expectThemeNotSelected('Keep raw transcript');
+    });
+
+    testWidgets('tapping handling option calls cubit (#32)', (tester) async {
+      final mockSettingsCubit = MockSettingsCubit();
+      when(
+        () => mockSettingsCubit.state,
+      ).thenReturn(const SettingsState(loaded: true));
+      when(
+        () => mockSettingsCubit.setVoiceNoteHandling(any()),
+      ).thenAnswer((_) async {});
+
+      await tester.pumpApp(
+        const SettingsScreen(),
+        settingsCubit: mockSettingsCubit,
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      robot = SettingsScreenRobot(tester);
+      await robot.scrollTo(find.text('Keep raw transcript'));
+      await tester.tap(find.text('Keep raw transcript'));
+      await tester.pump();
+
+      verify(
+        () => mockSettingsCubit.setVoiceNoteHandling(VoiceNoteHandling.raw),
+      ).called(1);
     });
 
     testWidgets('toggles daily call calls cubit', (tester) async {

--- a/test/widgets/voice_recording_sheet_test.dart
+++ b/test/widgets/voice_recording_sheet_test.dart
@@ -544,7 +544,8 @@ void main() {
   });
 
   group('LLM error during categorization', () {
-    testWidgets('shows error state when LLM throws', (tester) async {
+    testWidgets('falls back to raw review when LLM throws '
+        '(owner-verify: Gemini 500)', (tester) async {
       await openSheetToTranscriptReview(tester, 'Some text');
 
       when(
@@ -558,8 +559,11 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(seconds: 1));
 
-      expect(find.text('Something went wrong'), findsOneWidget);
-      expect(find.textContaining('Failed to categorize'), findsOneWidget);
+      // The user's words survive the LLM outage: straight to review with
+      // the raw transcript, category picked manually — never a dead end.
+      expect(find.text('Review your note'), findsOneWidget);
+      expect(find.widgetWithText(TextField, 'Some text'), findsWidgets);
+      expect(find.text('Something went wrong'), findsNothing);
     });
   });
 

--- a/test/widgets/voice_recording_sheet_test.dart
+++ b/test/widgets/voice_recording_sheet_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:dytty/data/models/category_config.dart';
 import 'package:dytty/features/settings/cubit/category_cubit.dart';
+import 'package:dytty/features/settings/cubit/settings_cubit.dart';
 import 'package:dytty/features/voice_note/voice_note_result.dart';
 import 'package:dytty/features/voice_note/widgets/voice_recording_sheet.dart';
 import 'package:dytty/services/llm/llm_service.dart';
@@ -49,7 +50,14 @@ void main() {
 
   /// Builds a widget tree with all required providers, then taps a button
   /// to open the voice recording sheet via the real [showVoiceRecordingSheet].
-  Future<void> openSheet(WidgetTester tester) async {
+  Future<void> openSheet(
+    WidgetTester tester, {
+    VoiceNoteHandling handling = VoiceNoteHandling.ask,
+  }) async {
+    final settingsCubit = MockSettingsCubit();
+    when(
+      () => settingsCubit.state,
+    ).thenReturn(SettingsState(loaded: true, voiceNoteHandling: handling));
     await tester.pumpWidget(
       MaterialApp(
         home: MultiRepositoryProvider(
@@ -59,8 +67,11 @@ void main() {
             ),
             RepositoryProvider<LlmService>(create: (_) => mockLlm),
           ],
-          child: BlocProvider<CategoryCubit>.value(
-            value: mockCategoryCubit,
+          child: MultiBlocProvider(
+            providers: [
+              BlocProvider<CategoryCubit>.value(value: mockCategoryCubit),
+              BlocProvider<SettingsCubit>.value(value: settingsCubit),
+            ],
             child: Builder(
               builder: (context) => Scaffold(
                 body: ElevatedButton(
@@ -552,6 +563,54 @@ void main() {
     });
   });
 
+  group('save-as-is and handling preference (#32)', () {
+    testWidgets('transcriptReview shows Save as-is between Discard and '
+        'Summarize', (tester) async {
+      await openSheetToTranscriptReview(tester, 'raw words');
+
+      expect(find.text('Discard'), findsOneWidget);
+      expect(find.text('Save as-is'), findsOneWidget);
+      expect(find.text('Summarize'), findsOneWidget);
+    });
+
+    testWidgets('Save as-is reaches reviewing with raw transcript, no LLM', (
+      tester,
+    ) async {
+      await openSheetToTranscriptReview(tester, 'keep this exact text');
+
+      await tester.tap(find.text('Save as-is'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('Review your note'), findsOneWidget);
+      expect(
+        find.widgetWithText(TextField, 'keep this exact text'),
+        findsWidgets,
+      );
+      verifyNever(
+        () => mockLlm.categorizeEntry(
+          any(),
+          categoryIds: any(named: 'categoryIds'),
+        ),
+      );
+    });
+
+    testWidgets('handling=raw skips transcriptReview entirely', (tester) async {
+      setupSttWithImmediateFinalResult('straight to review');
+      await openSheet(tester, handling: VoiceNoteHandling.raw);
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('Review transcript'), findsNothing);
+      expect(find.text('Review your note'), findsOneWidget);
+      verifyNever(
+        () => mockLlm.categorizeEntry(
+          any(),
+          categoryIds: any(named: 'categoryIds'),
+        ),
+      );
+    });
+  });
+
   group('cancel button (#187)', () {
     testWidgets('visible in unavailable state', (tester) async {
       await openSheet(tester);
@@ -674,6 +733,10 @@ void main() {
       ).thenAnswer((_) async {});
 
       // Inline variant of openSheet that captures the sheet's result future.
+      final settingsCubit = MockSettingsCubit();
+      when(
+        () => settingsCubit.state,
+      ).thenReturn(const SettingsState(loaded: true));
       Future<VoiceNoteResult?>? resultFuture;
       await tester.pumpWidget(
         MaterialApp(
@@ -684,8 +747,11 @@ void main() {
               ),
               RepositoryProvider<LlmService>(create: (_) => mockLlm),
             ],
-            child: BlocProvider<CategoryCubit>.value(
-              value: mockCategoryCubit,
+            child: MultiBlocProvider(
+              providers: [
+                BlocProvider<CategoryCubit>.value(value: mockCategoryCubit),
+                BlocProvider<SettingsCubit>.value(value: settingsCubit),
+              ],
               child: Builder(
                 builder: (context) => Scaffold(
                   body: ElevatedButton(

--- a/test/widgets/voice_recording_sheet_test.dart
+++ b/test/widgets/voice_recording_sheet_test.dart
@@ -595,6 +595,18 @@ void main() {
       );
     });
 
+    testWidgets('transcriptReview action row fits a 360dp-wide screen', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(360, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      // Overflow throws a RenderFlex exception in debug, failing the test.
+      await openSheetToTranscriptReview(tester, 'narrow screen check');
+      expect(find.text('Save as-is'), findsOneWidget);
+    });
+
     testWidgets('handling=raw skips transcriptReview entirely', (tester) async {
       setupSttWithImmediateFinalResult('straight to review');
       await openSheet(tester, handling: VoiceNoteHandling.raw);


### PR DESCRIPTION
Fixes #32

## What

Completes the voice review flow with a no-LLM path and a persistent handling preference:

- **Save as-is** button on the transcript review step — keeps the raw transcript as the entry text, skips the LLM entirely (no category suggestion; user picks manually).
- **Voice notes** settings section with three options: *Ask each time* (default, current behavior), *Summarize automatically* (skips transcript review straight to LLM), *Keep raw transcript* (skips both review pause and LLM).
- Preference persists in the user settings profile doc (`voiceNoteHandling`) and round-trips through `SettingsCubit` with the same optimistic+revert pattern as `hideEntries`.
- `VoiceNoteHandling` enum moved to `core/constants` (shared by bloc, cubit, sheet); old import sites re-export for compatibility.

Audio storage portion of the original issue was split out to #213 per the group-3 decision (keep everything local for now).

## Key decisions

- Routing lives in `VoiceNoteBloc._advancePastTranscript` — both final-STT-result and manual Stop funnel through it, so summarize/raw behave identically regardless of how listening ended.
- Save-as-is leaves `suggestedCategory` null; Save stays disabled until the user picks a category, so raw entries can't land uncategorized.
- Settings UI reuses the theme-picker checkmark tile pattern rather than RadioListTile (deprecated group API in Flutter 3.41).

## Tests

- Bloc: 4 new blocTests (SkipCategorization, handling=summarize/raw routing, default ask pause).
- Repository: round-trip + default for `voiceNoteHandling`.
- Cubit: set/persist/revert + loadSettings mapping.
- Widget: Save-as-is renders and reaches reviewing with no LLM call; handling=raw skips transcript review; settings section render/selection/tap tests.
- Full suite: 832 tests green. Developer-section tests fixed to scroll to their actual targets (new section pushed them past the lazy ListView viewport).

## Device verification (Pixel 9a, real Firebase)

- Voice notes section renders in Settings, checkmark moves on tap.
- Preference survives force-stop + relaunch (persisted to Firestore).
- Reset to default *Ask each time* afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)