### PR TITLE
fix(test): nightly provisioning + harness retry hygiene (review findings)

### DIFF
--- a/.github/workflows/voice-nightly.yml
+++ b/.github/workflows/voice-nightly.yml
@@ -4,10 +4,14 @@ name: "Voice Nightly: Acoustic E2E"
 # STT/Gemini -> logcat. Runs nightly and on demand on the self-hosted
 # runner with the physical phone. Calibration gates the run so
 # environment drift (speaker moved/changed) fails loudly up front.
+#
+# Provisioning mirrors ci.yml's Gate 1.5 device job: checkout wipes
+# gitignored files (.env, google-services.json), so everything comes
+# from secrets/actions — never from files assumed on the runner.
 
 on:
   schedule:
-    - cron: "0 7 * * *" # 03:00 America/Toronto
+    - cron: "0 7 * * *" # 07:00 UTC = 03:00 EDT / 02:00 EST
   workflow_dispatch:
 
 concurrency:
@@ -18,23 +22,68 @@ jobs:
   acoustic-e2e:
     name: "Acoustic E2E (physical phone)"
     runs-on: [self-hosted, device-test]
-    timeout-minutes: 45
+    timeout-minutes: 75 # 8 flows x 2 attempts x 180s watchdog + build + TTS
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build debug APK
+      - name: Check device connected
         shell: bash
         run: |
-          FIREBASE_KEY=$(grep FIREBASE_ANDROID_API_KEY .env | cut -d= -f2)
-          GEMINI_KEY=$(grep GEMINI_API_KEY .env | cut -d= -f2)
+          export PATH="$PATH:$LOCALAPPDATA/Android/Sdk/platform-tools"
+          DEVICE_COUNT=$(adb devices | grep -v 'emulator' | grep -c 'device$' || true)
+          if [[ "$DEVICE_COUNT" -eq 0 ]]; then
+            echo "::error::No physical device connected — nightly cannot run."
+            exit 1
+          fi
+          echo "Device: $(adb devices | grep 'device$' | head -1)"
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.41.1'
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Restore google-services.json
+        shell: bash
+        run: echo '${{ secrets.GOOGLE_SERVICES_JSON }}' > android/app/google-services.json
+
+      - name: Cache harness Python deps
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: harness-pip-${{ hashFiles('tools/acoustic-harness/requirements.txt') }}
+
+      - name: Install harness deps + preflight
+        shell: bash
+        run: |
+          python -m pip install -r tools/acoustic-harness/requirements.txt
+          python -c "import sounddevice, soundfile; print('audio deps ok')"
+          export PATH="$PATH:$LOCALAPPDATA/Android/Sdk/platform-tools"
+          command -v adb && command -v maestro
+
+      - name: Build debug APK
+        shell: bash
+        env:
+          FIREBASE_ANDROID_API_KEY: ${{ secrets.FIREBASE_ANDROID_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: |
+          export PATH="$PATH:$LOCALAPPDATA/Android/Sdk/platform-tools"
           flutter build apk --debug \
-            --dart-define=FIREBASE_ANDROID_API_KEY="$FIREBASE_KEY" \
-            --dart-define=GEMINI_API_KEY="$GEMINI_KEY"
+            --dart-define=FIREBASE_ANDROID_API_KEY="$FIREBASE_ANDROID_API_KEY" \
+            --dart-define=GEMINI_API_KEY="$GEMINI_API_KEY"
           adb install -r build/app/outputs/flutter-apk/app-debug.apk
 
       - name: Calibrate + sweep
         shell: bash
-        run: bash scripts/voice-sweep.sh
+        env:
+          DEVICE_TEST_EMAIL: ${{ secrets.DEVICE_TEST_EMAIL }}
+          DEVICE_TEST_UID: ${{ secrets.DEVICE_TEST_UID }}
+        run: |
+          export PATH="$PATH:$LOCALAPPDATA/Android/Sdk/platform-tools"
+          bash scripts/voice-sweep.sh
 
       - name: Upload failure artifacts
         if: failure()

--- a/.maestro/voice/voice-note-basic.yaml
+++ b/.maestro/voice/voice-note-basic.yaml
@@ -13,17 +13,17 @@ tags:
 # Wait for listening (orchestrator plays audio here)
 - extendedWaitUntil:
     visible: ".*Listening.*"
-    timeout: 5000
+    timeout: 3000
 
 # Wait for transcript review screen
 - extendedWaitUntil:
     visible: "Review transcript"
-    timeout: 20000
+    timeout: 16000
 
 # Assert transcript has content
 - extendedWaitUntil:
     visible: ".*grocery.*"
-    timeout: 5000
+    timeout: 3000
 
 # Tap Summarize
 - tapOn: "Summarize"
@@ -31,7 +31,7 @@ tags:
 # Wait for reviewing state
 - extendedWaitUntil:
     visible: "Review your note"
-    timeout: 15000
+    timeout: 12000
 
 # Assert key review elements visible
 - assertVisible: "Summary"
@@ -46,4 +46,4 @@ tags:
 # Assert entry was saved — journal detail or home screen visible
 - extendedWaitUntil:
     visible: ".*Positive Things.*"
-    timeout: 5000
+    timeout: 3000

--- a/.maestro/voice/voice-note-category-select.yaml
+++ b/.maestro/voice/voice-note-category-select.yaml
@@ -10,17 +10,17 @@ tags:
 
 - extendedWaitUntil:
     visible: ".*Listening.*"
-    timeout: 5000
+    timeout: 3000
 
 - extendedWaitUntil:
     visible: "Review transcript"
-    timeout: 20000
+    timeout: 16000
 
 - tapOn: "Summarize"
 
 - extendedWaitUntil:
     visible: "Review your note"
-    timeout: 15000
+    timeout: 12000
 
 # Assert Category label visible
 - assertVisible: "Category"
@@ -34,4 +34,4 @@ tags:
 # Assert entry saved under Gratitude
 - extendedWaitUntil:
     visible: ".*Gratitude.*"
-    timeout: 5000
+    timeout: 3000

--- a/.maestro/voice/voice-note-discard.yaml
+++ b/.maestro/voice/voice-note-discard.yaml
@@ -10,16 +10,16 @@ tags:
 
 - extendedWaitUntil:
     visible: ".*Listening.*"
-    timeout: 5000
+    timeout: 3000
 
 - extendedWaitUntil:
     visible: "Review transcript"
-    timeout: 20000
+    timeout: 16000
 
 # Assert transcript has content
 - extendedWaitUntil:
     visible: ".*grocery.*"
-    timeout: 5000
+    timeout: 3000
 
 # Tap Discard
 - tapOn: "Discard"
@@ -31,6 +31,6 @@ tags:
 # "haven't journaled" banner does not).
 - extendedWaitUntil:
     visible: 'Progress \d of 5.*'
-    timeout: 5000
+    timeout: 3000
 - assertNotVisible: "Review transcript"
 

--- a/.maestro/voice/voice-note-edit-transcript.yaml
+++ b/.maestro/voice/voice-note-edit-transcript.yaml
@@ -10,12 +10,12 @@ tags:
 
 - extendedWaitUntil:
     visible: ".*Listening.*"
-    timeout: 5000
+    timeout: 3000
 
 # Wait for transcript review
 - extendedWaitUntil:
     visible: "Review transcript"
-    timeout: 20000
+    timeout: 16000
 
 # Tap transcript text to focus the field, then append edited text
 - tapOn: ".*grocery.*"
@@ -30,7 +30,7 @@ tags:
 # Wait for review
 - extendedWaitUntil:
     visible: "Review your note"
-    timeout: 15000
+    timeout: 12000
 
 # Assert we reached the review screen
 - assertVisible: "Summary"

--- a/.maestro/voice/voice-note-edited-badge.yaml
+++ b/.maestro/voice/voice-note-edited-badge.yaml
@@ -10,17 +10,17 @@ tags:
 
 - extendedWaitUntil:
     visible: ".*Listening.*"
-    timeout: 5000
+    timeout: 3000
 
 - extendedWaitUntil:
     visible: "Review transcript"
-    timeout: 20000
+    timeout: 16000
 
 - tapOn: "Summarize"
 
 - extendedWaitUntil:
     visible: "Review your note"
-    timeout: 15000
+    timeout: 12000
 
 # Assert "edited" badge is NOT visible before editing
 - assertNotVisible: "edited"
@@ -41,4 +41,4 @@ tags:
 # This proves the "edited" badge is also showing (same condition)
 - extendedWaitUntil:
     visible: "Re-summarize"
-    timeout: 5000
+    timeout: 3000

--- a/.maestro/voice/voice-note-no-tags.yaml
+++ b/.maestro/voice/voice-note-no-tags.yaml
@@ -10,17 +10,17 @@ tags:
 
 - extendedWaitUntil:
     visible: ".*Listening.*"
-    timeout: 5000
+    timeout: 3000
 
 - extendedWaitUntil:
     visible: "Review transcript"
-    timeout: 20000
+    timeout: 16000
 
 - tapOn: "Summarize"
 
 - extendedWaitUntil:
     visible: "Review your note"
-    timeout: 15000
+    timeout: 12000
 
 # Assert tags section is NOT visible
 - assertNotVisible: "Tags"

--- a/.maestro/voice/voice-note-re-summarize.yaml
+++ b/.maestro/voice/voice-note-re-summarize.yaml
@@ -10,17 +10,17 @@ tags:
 
 - extendedWaitUntil:
     visible: ".*Listening.*"
-    timeout: 5000
+    timeout: 3000
 
 - extendedWaitUntil:
     visible: "Review transcript"
-    timeout: 20000
+    timeout: 16000
 
 - tapOn: "Summarize"
 
 - extendedWaitUntil:
     visible: "Review your note"
-    timeout: 15000
+    timeout: 12000
 
 # Expand transcript and edit
 - tapOn: "Transcript"
@@ -39,5 +39,5 @@ tags:
 # the button returns and the review screen is still intact.
 - extendedWaitUntil:
     visible: "Re-summarize"
-    timeout: 20000
+    timeout: 12000
 - assertVisible: "Review your note"

--- a/.maestro/voice/voice-note-save-disabled.yaml
+++ b/.maestro/voice/voice-note-save-disabled.yaml
@@ -10,11 +10,11 @@ tags:
 
 - extendedWaitUntil:
     visible: ".*Listening.*"
-    timeout: 5000
+    timeout: 3000
 
 - extendedWaitUntil:
     visible: "Review transcript"
-    timeout: 20000
+    timeout: 16000
 
 # Save-as-is (#32) guarantees NO category is pre-selected — the old
 # Summarize path gambled on the LLM not suggesting one (it usually
@@ -23,7 +23,7 @@ tags:
 
 - extendedWaitUntil:
     visible: "Review your note"
-    timeout: 15000
+    timeout: 12000
 
 # Tap Save — disabled with no category, we stay on review screen
 - tapOn: "Save"
@@ -37,7 +37,9 @@ tags:
 # Tap Save again — should work now
 - tapOn: "Save"
 
-# Assert we left the review screen
+# Prove we LEFT the review screen: the category chip alone is vacuous
+# (it is visible on the review screen we might be stuck on).
+- assertNotVisible: "Review your note"
 - extendedWaitUntil:
-    visible: ".*Positive Things.*"
-    timeout: 5000
+    visible: 'Progress \d of 5.*'
+    timeout: 3000

--- a/lib/features/voice_note/bloc/voice_note_bloc.dart
+++ b/lib/features/voice_note/bloc/voice_note_bloc.dart
@@ -353,6 +353,9 @@ class VoiceNoteBloc extends Bloc<VoiceNoteEvent, VoiceNoteState> {
       // Any LLM unavailability — timeout, server overload (Gemini 500),
       // network — degrades to raw review: the user's words are never
       // hostage to the model, they just pick the category manually.
+      // Logged like every routed state: the harness orchestrator and
+      // verify.py key off [DYTTY] state lines.
+      _log('Voice note state: reviewing');
       emit(
         VoiceNoteState(
           status: VoiceNoteStatus.reviewing,

--- a/scripts/voice-sweep.sh
+++ b/scripts/voice-sweep.sh
@@ -12,26 +12,37 @@ PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HARNESS="${ACOUSTIC_HARNESS_HOME:-$PROJECT_DIR/tools/acoustic-harness}"
 SCRIPTS_JSON="$PROJECT_DIR/test/fixtures/audio/test-scripts.json"
 WAVS="$PROJECT_DIR/test/fixtures/audio/generated"
-LOCK="$PROJECT_DIR/.device.lock"
+LOCK_DIR="$PROJECT_DIR/.device.lock.d"
 export ACOUSTIC_TAG="${ACOUSTIC_TAG:-DYTTY}"
 
-EMAIL="${DEVICE_TEST_EMAIL:-$(grep '^DEVICE_TEST_EMAIL=' "$PROJECT_DIR/.env" | cut -d= -f2)}"
+# -f2- (not -f2): values may contain '='. || true: missing file/key must
+# reach the friendly error below, not die on set -e at the assignment.
+EMAIL="${DEVICE_TEST_EMAIL:-$(grep '^DEVICE_TEST_EMAIL=' "$PROJECT_DIR/.env" 2>/dev/null | cut -d= -f2- || true)}"
 if [[ -z "$EMAIL" ]]; then
   echo "ERROR: DEVICE_TEST_EMAIL not set and not in .env" >&2
   exit 2
 fi
 
-# Minimal device lock (#191): refuse to start if another run holds the
-# phone; stale locks (>30 min) are reclaimed.
-if [[ -f "$LOCK" ]]; then
-  if [[ -n "$(find "$LOCK" -mmin -30 2>/dev/null)" ]]; then
-    echo "ERROR: device locked by another run ($(cat "$LOCK")). Remove $LOCK if stale." >&2
+# Device lock (#191): mkdir is atomic — no check-then-write race.
+# Staleness from the epoch timestamp inside the lock (find -mmin is
+# unreliable when PATH resolves Windows' find.exe).
+acquire_lock() {
+  if mkdir "$LOCK_DIR" 2>/dev/null; then
+    echo "$(date +%s) pid=$$" > "$LOCK_DIR/owner"
+    return 0
+  fi
+  local held_at now
+  held_at=$(cut -d' ' -f1 "$LOCK_DIR/owner" 2>/dev/null || echo 0)
+  now=$(date +%s)
+  if (( now - held_at < 1800 )); then
+    echo "ERROR: device locked ($(cat "$LOCK_DIR/owner" 2>/dev/null)). Remove $LOCK_DIR if stale." >&2
     exit 3
   fi
-  echo "WARN: reclaiming stale lock ($(cat "$LOCK"))"
-fi
-echo "voice-sweep pid=$$ started=$(date -Iseconds)" > "$LOCK"
-trap 'rm -f "$LOCK"' EXIT
+  echo "WARN: reclaiming stale lock ($(cat "$LOCK_DIR/owner" 2>/dev/null))"
+  echo "$(date +%s) pid=$$" > "$LOCK_DIR/owner"
+}
+acquire_lock
+trap 'rm -rf "$LOCK_DIR"' EXIT
 
 if [[ "${1:-}" != "--skip-calibration" ]]; then
   python "$HARNESS/calibrate.py" \
@@ -56,6 +67,8 @@ overall=0
 SECONDS=0
 for f in "${FLOWS[@]}"; do
   t0=$SECONDS
+  # All flows share one spoken input (voice-note-basic scenario) by
+  # design — they diverge AFTER the transcript arrives.
   if out=$(python "$HARNESS/orchestrate.py" \
       --scenario voice-note-basic \
       --scripts "$SCRIPTS_JSON" --wavs "$WAVS" \
@@ -70,7 +83,7 @@ for f in "${FLOWS[@]}"; do
   retries=$(grep -c RETRY <<< "$out" || true)
   echo "$f: $status $((SECONDS - t0))s retries=$retries"
   if [[ "$status" == FAIL ]]; then
-    grep -E "FAILED|WATCHDOG|NOT played" <<< "$out" | head -3 || true
+    grep -iE "fail|watchdog|not played" <<< "$out" | head -4 || true
   fi
 done
 echo "TOTAL: ${SECONDS}s"

--- a/scripts/voice-sweep.sh
+++ b/scripts/voice-sweep.sh
@@ -33,6 +33,9 @@ acquire_lock() {
   fi
   local held_at now
   held_at=$(cut -d' ' -f1 "$LOCK_DIR/owner" 2>/dev/null || echo 0)
+  # Empty owner file (interrupted write) yields "" — arithmetic on an
+  # empty string aborts under set -e. Sanitize to 0 (= stale, reclaim).
+  [[ "$held_at" =~ ^[0-9]+$ ]] || held_at=0
   now=$(date +%s)
   if (( now - held_at < 1800 )); then
     echo "ERROR: device locked ($(cat "$LOCK_DIR/owner" 2>/dev/null)). Remove $LOCK_DIR if stale." >&2

--- a/tools/acoustic-harness/orchestrate.py
+++ b/tools/acoustic-harness/orchestrate.py
@@ -276,8 +276,15 @@ def run_maestro(
     cmd.append(flow_path)
 
     print(f"  Maestro: {os.path.basename(flow_path)}")
+    # start_new_session: on POSIX the child gets its own process group —
+    # without it, _kill_tree's killpg would target OUR group (suicide).
+    # Ignored on Windows (taskkill /T path).
     proc = subprocess.Popen(
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
     )
     try:
         stdout, _ = proc.communicate(timeout=timeout_seconds)
@@ -307,7 +314,11 @@ def _kill_tree(pid: int) -> None:
         import signal
 
         try:
-            os.killpg(os.getpgid(pid), signal.SIGKILL)
+            pgid = os.getpgid(pid)
+            # Never kill our own group — if the child somehow shares it
+            # (start_new_session missed), killpg here would be suicide.
+            if pgid != os.getpgrp():
+                os.killpg(pgid, signal.SIGKILL)
         except (ProcessLookupError, PermissionError):
             pass
 

--- a/tools/acoustic-harness/orchestrate.py
+++ b/tools/acoustic-harness/orchestrate.py
@@ -101,8 +101,16 @@ def run_logcat_monitor(
     triggers: list[LogcatTrigger],
     log_path: str,
     stop_event: threading.Event,
+    proc_holder: dict | None = None,
 ) -> None:
-    """Background thread: stream logcat, feed lines to triggers, write to log."""
+    """Background thread: stream logcat, feed lines to triggers, write to log.
+
+    proc_holder (if given) receives the adb Popen under key "proc" so
+    the owner can kill it from outside: a thread blocked in readline()
+    never re-checks stop_event, survives join(timeout), and poisons the
+    next retry attempt (stale trigger double-fires audio; two writers
+    corrupt session.log).
+    """
     try:
         proc = subprocess.Popen(
             ["adb", "logcat", "-v", "time", "flutter:V", "*:S"],
@@ -114,6 +122,8 @@ def run_logcat_monitor(
     except FileNotFoundError:
         print("ERROR: ADB not found in PATH")
         return
+    if proc_holder is not None:
+        proc_holder["proc"] = proc
 
     tag_marker = f"[{tag}]"
 
@@ -266,21 +276,40 @@ def run_maestro(
     cmd.append(flow_path)
 
     print(f"  Maestro: {os.path.basename(flow_path)}")
+    proc = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+    )
     try:
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=timeout_seconds,
-        )
+        stdout, _ = proc.communicate(timeout=timeout_seconds)
     except subprocess.TimeoutExpired:
+        # Kill the TREE: a plain child-kill leaves the Maestro JVM
+        # grandchild alive on Windows, re-wedging the device for every
+        # following flow.
+        _kill_tree(proc.pid)
+        proc.communicate()  # drain pipes, reap
         print(f"    WATCHDOG: Maestro exceeded {timeout_seconds:.0f}s — "
-              "killed (wedged daemon?)")
+              "process tree killed (wedged daemon?)")
         return 124
-    if result.stdout:
-        for line in result.stdout.strip().split("\n"):
+    if stdout:
+        for line in stdout.strip().split("\n"):
             print(f"    {line}")
-    return result.returncode
+    return proc.returncode
+
+
+def _kill_tree(pid: int) -> None:
+    """Kill a process and all descendants (platform-aware)."""
+    if sys.platform.startswith("win"):
+        subprocess.run(
+            ["taskkill", "/F", "/T", "/PID", str(pid)],
+            capture_output=True,
+        )
+    else:
+        import signal
+
+        try:
+            os.killpg(os.getpgid(pid), signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            pass
 
 
 def run_verify(
@@ -426,9 +455,10 @@ def _run_attempt(args, config, scenario, tag, log_path, preloaded_wavs,
 
     # Step 3: Start logcat monitor
     stop_monitor = threading.Event()
+    monitor_proc: dict = {}
     monitor_thread = threading.Thread(
         target=run_logcat_monitor,
-        args=(tag, [trigger], log_path, stop_monitor),
+        args=(tag, [trigger], log_path, stop_monitor, monitor_proc),
         daemon=True,
     )
     monitor_thread.start()
@@ -453,6 +483,14 @@ def _run_attempt(args, config, scenario, tag, log_path, preloaded_wavs,
 
     # Step 5: Stop logcat monitor
     stop_monitor.set()
+    # Kill the adb pipe FIRST: a quiet logcat leaves the thread blocked
+    # in readline() past any join timeout, and a survivor poisons the
+    # retry attempt.
+    if monitor_proc.get("proc") is not None:
+        try:
+            monitor_proc["proc"].kill()
+        except OSError:
+            pass
     monitor_thread.join(timeout=5)
 
     # Step 6: Verify (daily call only)
@@ -478,7 +516,12 @@ def _run_attempt(args, config, scenario, tag, log_path, preloaded_wavs,
 
     if not overall:
         # Preserve evidence before a retry overwrites session.log.
-        fail_log = log_path.replace(".log", f".fail-{attempt_no}.log")
+        # Flow-prefixed: attempt numbering restarts per invocation; a
+        # sweep would otherwise keep only the last failing flow's logs.
+        flow_name = os.path.splitext(os.path.basename(args.flow))[0]
+        fail_log = log_path.replace(
+            ".log", f".{flow_name}.fail-{attempt_no}.log"
+        )
         try:
             import shutil
 

--- a/tools/acoustic-harness/tests/test_orchestrate.py
+++ b/tools/acoustic-harness/tests/test_orchestrate.py
@@ -261,17 +261,91 @@ class TestRunMaestroWatchdog(unittest.TestCase):
 
         from orchestrate import run_maestro
 
-        with mock.patch("orchestrate.subprocess.run") as m:
-            m.side_effect = sp.TimeoutExpired(cmd="maestro", timeout=5)
+        fake_proc = mock.Mock()
+        fake_proc.pid = 1
+        fake_proc.communicate.side_effect = [
+            sp.TimeoutExpired(cmd="maestro", timeout=5),
+            ("", ""),
+        ]
+        with mock.patch("orchestrate.subprocess.Popen",
+                        return_value=fake_proc), \
+                mock.patch("orchestrate._kill_tree"):
             rc = run_maestro("flow.yaml", timeout_seconds=5)
         self.assertEqual(rc, 124)
 
-    def test_passes_timeout_to_subprocess(self):
+    def test_passes_timeout_to_communicate(self):
         from unittest import mock
 
         from orchestrate import run_maestro
 
-        with mock.patch("orchestrate.subprocess.run") as m:
-            m.return_value = mock.Mock(stdout="", returncode=0)
+        fake_proc = mock.Mock()
+        fake_proc.pid = 1
+        fake_proc.communicate.return_value = ("", "")
+        fake_proc.returncode = 0
+        with mock.patch("orchestrate.subprocess.Popen",
+                        return_value=fake_proc):
             run_maestro("flow.yaml", timeout_seconds=77)
-        self.assertEqual(m.call_args.kwargs.get("timeout"), 77)
+        self.assertEqual(
+            fake_proc.communicate.call_args.kwargs.get("timeout"), 77
+        )
+
+
+class TestMonitorProcHolder(unittest.TestCase):
+    """A retry must be able to kill the previous attempt's adb logcat —
+    a thread blocked in readline() survives stop_event + join(5) and
+    poisons the next attempt (double audio fire, two session.log
+    writers)."""
+
+    def test_holder_receives_popen_for_external_kill(self):
+        import tempfile
+        import threading
+        from unittest import mock
+
+        from orchestrate import run_logcat_monitor
+
+        fake_proc = mock.Mock()
+        fake_proc.stdout = None  # loop exits immediately on None stdout
+        fake_proc.poll.return_value = 0
+        with mock.patch("orchestrate.subprocess.Popen", return_value=fake_proc):
+            holder = {}
+            run_logcat_monitor(
+                "DYTTY", [], os.path.join(tempfile.mkdtemp(), "l.log"),
+                threading.Event(), proc_holder=holder,
+            )
+        self.assertIs(holder.get("proc"), fake_proc)
+
+
+class TestKillTree(unittest.TestCase):
+    """Watchdog must kill the Maestro JVM grandchild, not just the
+    launcher — otherwise the wedged daemon it guards against is
+    recreated for every following flow."""
+
+    def test_windows_uses_taskkill_tree(self):
+        from unittest import mock
+
+        from orchestrate import _kill_tree
+
+        with mock.patch("orchestrate.subprocess.run") as m,                 mock.patch("orchestrate.sys.platform", "win32"):
+            _kill_tree(4242)
+        cmd = m.call_args.args[0]
+        self.assertIn("taskkill", cmd[0])
+        self.assertIn("/T", cmd)
+        self.assertIn("4242", cmd)
+
+    def test_run_maestro_timeout_kills_tree_returns_124(self):
+        from unittest import mock
+        import subprocess as sp
+
+        from orchestrate import run_maestro
+
+        fake_proc = mock.Mock()
+        fake_proc.pid = 777
+        fake_proc.communicate.side_effect = [
+            sp.TimeoutExpired(cmd="maestro", timeout=1),
+            ("", ""),
+        ]
+        with mock.patch("orchestrate.subprocess.Popen",
+                        return_value=fake_proc),                 mock.patch("orchestrate._kill_tree") as kt:
+            rc = run_maestro("flow.yaml", timeout_seconds=1)
+        self.assertEqual(rc, 124)
+        kt.assert_called_once_with(777)

--- a/tools/acoustic-harness/tests/test_orchestrate.py
+++ b/tools/acoustic-harness/tests/test_orchestrate.py
@@ -349,3 +349,47 @@ class TestKillTree(unittest.TestCase):
             rc = run_maestro("flow.yaml", timeout_seconds=1)
         self.assertEqual(rc, 124)
         kt.assert_called_once_with(777)
+
+
+class TestKillTreePosixSafety(unittest.TestCase):
+    """killpg on the orchestrator's own process group is suicide; the
+    child must be started in a new session and the guard must refuse
+    same-group kills."""
+
+    def test_posix_guard_refuses_own_process_group(self):
+        from unittest import mock
+
+        import orchestrate
+
+        with mock.patch.object(orchestrate.sys, "platform", "linux"),                 mock.patch.object(orchestrate.os, "getpgid",
+                                  return_value=555, create=True),                 mock.patch.object(orchestrate.os, "getpgrp",
+                                  return_value=555, create=True),                 mock.patch.object(orchestrate.os, "killpg",
+                                  create=True) as kp:
+            orchestrate._kill_tree(123)
+        kp.assert_not_called()
+
+    def test_posix_kills_foreign_process_group(self):
+        from unittest import mock
+
+        import orchestrate
+
+        with mock.patch.object(orchestrate.sys, "platform", "linux"),                 mock.patch.object(orchestrate.os, "getpgid",
+                                  return_value=555, create=True),                 mock.patch.object(orchestrate.os, "getpgrp",
+                                  return_value=999, create=True),                 mock.patch.object(orchestrate.os, "killpg",
+                                  create=True) as kp:
+            orchestrate._kill_tree(123)
+        kp.assert_called_once()
+
+    def test_maestro_child_starts_new_session(self):
+        from unittest import mock
+
+        from orchestrate import run_maestro
+
+        fake_proc = mock.Mock()
+        fake_proc.pid = 1
+        fake_proc.communicate.return_value = ("", "")
+        fake_proc.returncode = 0
+        with mock.patch("orchestrate.subprocess.Popen",
+                        return_value=fake_proc) as popen:
+            run_maestro("flow.yaml", timeout_seconds=5)
+        self.assertTrue(popen.call_args.kwargs.get("start_new_session"))


### PR DESCRIPTION
Fast-follow for #217 from the agent code review: the nightly workflow could not run as merged (no secrets provisioning post-checkout, no toolchain setup), voice-sweep.sh died before its own error message, and the orchestrator's retry path could be poisoned by the previous attempt's logcat monitor / orphaned Maestro JVM. Full details in the commit message. 90 harness tests green, bloc tests green, flows re-validated locally.

Once merged, PR #220 (promotion) picks this up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)