### PR TITLE
fix(daily-call): barge-in redesign — open-mic, AEC, interrupt handling, latency, transcripts

### DIFF
--- a/.maestro/voice/daily-call-liveness.yaml
+++ b/.maestro/voice/daily-call-liveness.yaml
@@ -26,10 +26,14 @@ tags:
     visible: "In call.*"
     timeout: 20000
 
-# Wait for AI response (orchestrator plays audio, AI processes)
+# Hold the call open for the AI's full audio response. A bare `visible: ".*"`
+# matches instantly and ends the call before the AI emits audio (no audio /
+# latency captured). waitForAnimationToEnd lets the response land first.
 - extendedWaitUntil:
-    visible: ".*"
-    timeout: 30000
+    visible: "End call"
+    timeout: 20000
+- waitForAnimationToEnd:
+    timeout: 15000
 
 # End call
 - tapOn: "End call"

--- a/.maestro/voice/daily-call-multi-turn.yaml
+++ b/.maestro/voice/daily-call-multi-turn.yaml
@@ -20,10 +20,15 @@ tags:
     visible: "In call.*"
     timeout: 20000
 
-# Orchestrator plays both utterances with Turn complete signals between them
+# Orchestrator plays both utterances with Turn complete signals between them.
+# Hold the call open long enough for the AI to finish BOTH audio turns —
+# a bare `visible: ".*"` matches instantly and ends the call before the AI
+# responds, so no AI audio is captured (breaks latency/audio measurement).
 - extendedWaitUntil:
-    visible: ".*"
+    visible: "End call"
     timeout: 45000
+- waitForAnimationToEnd:
+    timeout: 30000
 
 - tapOn: "End call"
 

--- a/lib/features/voice_call/bloc/voice_call_bloc.dart
+++ b/lib/features/voice_call/bloc/voice_call_bloc.dart
@@ -479,11 +479,14 @@ class VoiceCallBloc extends Bloc<VoiceCallEvent, VoiceCallState> {
     final current = state.transcripts;
     // If the AI was mid-turn, mark its bubble interrupted + finalize it so the
     // history records that the rest of that response was never heard (#12).
-    if (current.isNotEmpty &&
-        current.last.speaker == Speaker.ai &&
-        !current.last.isFinal) {
+    //
+    // Open-mic: the user's partial transcript may have already been appended
+    // before the interrupt signal arrives, so the AI bubble isn't necessarily
+    // last. Find the most recent AI bubble rather than assuming `current.last`.
+    final aiIndex = current.lastIndexWhere((t) => t.speaker == Speaker.ai);
+    if (aiIndex != -1 && !current[aiIndex].isFinal) {
       final updated = List<Transcript>.of(current);
-      updated[updated.length - 1] = current.last.copyWith(
+      updated[aiIndex] = current[aiIndex].copyWith(
         interrupted: true,
         isFinal: true,
       );

--- a/lib/features/voice_call/bloc/voice_call_bloc.dart
+++ b/lib/features/voice_call/bloc/voice_call_bloc.dart
@@ -411,6 +411,11 @@ class VoiceCallBloc extends Bloc<VoiceCallEvent, VoiceCallState> {
 
   void _onSessionTick(_SessionTick event, Emitter<VoiceCallState> emit) {
     if (_callStartTime == null) return;
+    // Never resurrect a terminal call from a stray in-flight tick (#227).
+    if (state.status == VoiceCallStatus.error ||
+        state.status == VoiceCallStatus.ended) {
+      return;
+    }
     final elapsed = DateTime.now().difference(_callStartTime!);
 
     // Auto-end at session limit
@@ -554,6 +559,11 @@ class VoiceCallBloc extends Bloc<VoiceCallEvent, VoiceCallState> {
           emit(state.copyWith(status: VoiceCallStatus.active));
         }
       case GeminiLiveState.error:
+        // #227: tear down the call clock so the periodic tick can't revert the
+        // status back to active (which would strand the user in a fake-active
+        // call against a dead socket).
+        _elapsedTimer?.cancel();
+        _callStartTime = null;
         emit(
           state.copyWith(
             status: VoiceCallStatus.error,

--- a/lib/features/voice_call/bloc/voice_call_bloc.dart
+++ b/lib/features/voice_call/bloc/voice_call_bloc.dart
@@ -244,6 +244,10 @@ class VoiceCallBloc extends Bloc<VoiceCallEvent, VoiceCallState> {
   /// Audio output stream for the UI to play back.
   Stream<Uint8List> get audioOutputStream => _service.audioStream;
 
+  /// Barge-in signal (#12): fires when Gemini cancels its turn because the
+  /// user spoke over the AI. The audio session flushes playback on this.
+  Stream<void> get interruptStream => _service.interruptStream;
+
   VoiceCallBloc({
     required GeminiLiveService service,
     JournalBloc? journalBloc,

--- a/lib/features/voice_call/bloc/voice_call_bloc.dart
+++ b/lib/features/voice_call/bloc/voice_call_bloc.dart
@@ -75,6 +75,11 @@ class GenerateSessionSummary extends VoiceCallEvent {
   List<Object?> get props => [transcripts];
 }
 
+/// User spoke over the AI; Gemini cancelled its turn (#12).
+class InterruptReceived extends VoiceCallEvent {
+  const InterruptReceived();
+}
+
 class ToggleMute extends VoiceCallEvent {
   const ToggleMute();
 }
@@ -226,6 +231,7 @@ class VoiceCallBloc extends Bloc<VoiceCallEvent, VoiceCallState> {
   final String? _uid;
 
   StreamSubscription<Transcript>? _transcriptSub;
+  StreamSubscription<void>? _interruptSub;
   StreamSubscription<FunctionCall>? _toolCallSub;
   StreamSubscription<GeminiLiveState>? _stateSub;
   StreamSubscription<int>? _latencySub;
@@ -268,6 +274,7 @@ class VoiceCallBloc extends Bloc<VoiceCallEvent, VoiceCallState> {
     on<LatencyUpdated>(_onLatencyUpdated);
     on<_SessionTick>(_onSessionTick);
     on<GenerateSessionSummary>(_onGenerateSessionSummary);
+    on<InterruptReceived>(_onInterruptReceived);
     on<ToggleMute>(_onToggleMute);
     on<ToggleSpeaker>(_onToggleSpeaker);
   }
@@ -302,6 +309,9 @@ class VoiceCallBloc extends Bloc<VoiceCallEvent, VoiceCallState> {
     });
     _latencySub = _service.latencyStream.listen((ms) {
       add(LatencyUpdated(ms));
+    });
+    _interruptSub = _service.interruptStream.listen((_) {
+      add(const InterruptReceived());
     });
 
     try {
@@ -451,6 +461,25 @@ class VoiceCallBloc extends Bloc<VoiceCallEvent, VoiceCallState> {
     }
   }
 
+  void _onInterruptReceived(
+    InterruptReceived event,
+    Emitter<VoiceCallState> emit,
+  ) {
+    final current = state.transcripts;
+    // If the AI was mid-turn, mark its bubble interrupted + finalize it so the
+    // history records that the rest of that response was never heard (#12).
+    if (current.isNotEmpty &&
+        current.last.speaker == Speaker.ai &&
+        !current.last.isFinal) {
+      final updated = List<Transcript>.of(current);
+      updated[updated.length - 1] = current.last.copyWith(
+        interrupted: true,
+        isFinal: true,
+      );
+      emit(state.copyWith(transcripts: updated));
+    }
+  }
+
   Future<void> _onToolCallReceived(
     ToolCallReceived event,
     Emitter<VoiceCallState> emit,
@@ -560,10 +589,12 @@ class VoiceCallBloc extends Bloc<VoiceCallEvent, VoiceCallState> {
     await _toolCallSub?.cancel();
     await _stateSub?.cancel();
     await _latencySub?.cancel();
+    await _interruptSub?.cancel();
     _transcriptSub = null;
     _toolCallSub = null;
     _stateSub = null;
     _latencySub = null;
+    _interruptSub = null;
   }
 
   @override

--- a/lib/features/voice_call/bloc/voice_call_bloc.dart
+++ b/lib/features/voice_call/bloc/voice_call_bloc.dart
@@ -448,15 +448,21 @@ class VoiceCallBloc extends Bloc<VoiceCallEvent, VoiceCallState> {
     final current = state.transcripts;
     final incoming = event.transcript;
 
-    // Append new bubble when: list is empty, speaker changed, or last was final
+    // New bubble when: list is empty, speaker changed, or last bubble is final.
     if (current.isEmpty ||
         current.last.speaker != incoming.speaker ||
         current.last.isFinal) {
       emit(state.copyWith(transcripts: [...current, incoming]));
     } else {
-      // Replace last partial with updated partial/final from same speaker
+      // #123: Gemini streams transcript as incremental DELTAS, so APPEND the
+      // delta to the running bubble rather than replacing it (replacing left
+      // only the last fragment visible — truncated speech).
       final updated = List<Transcript>.of(current);
-      updated[updated.length - 1] = incoming;
+      updated[updated.length - 1] = Transcript(
+        speaker: incoming.speaker,
+        text: current.last.text + incoming.text,
+        isFinal: incoming.isFinal,
+      );
       emit(state.copyWith(transcripts: updated));
     }
   }

--- a/lib/features/voice_call/voice_call_screen.dart
+++ b/lib/features/voice_call/voice_call_screen.dart
@@ -109,8 +109,17 @@ class _VoiceCallScreenState extends State<VoiceCallScreen> {
       value: _bloc,
       child: BlocListener<VoiceCallBloc, VoiceCallState>(
         listenWhen: (prev, curr) =>
-            curr.savedEntries.length > prev.savedEntries.length,
+            curr.savedEntries.length > prev.savedEntries.length ||
+            (curr.status == VoiceCallStatus.error &&
+                prev.status != VoiceCallStatus.error),
         listener: (context, state) {
+          // #227: the session dropped (e.g. WebSocket 1008) — stop the recorder
+          // so the mic isn't streaming into a dead socket.
+          if (state.status == VoiceCallStatus.error) {
+            _session?.stop();
+            return;
+          }
+
           final entry = state.savedEntries.last;
           final cat = CategoryConfig.defaults.firstWhere(
             (c) => c.id == entry.categoryId,

--- a/lib/services/audio/audio_playback_service.dart
+++ b/lib/services/audio/audio_playback_service.dart
@@ -11,6 +11,11 @@ abstract class AudioPlaybackService {
   /// Feed a chunk of raw PCM 16-bit little-endian audio data for playback.
   Future<void> feed(Uint8List pcmData);
 
+  /// Drop all queued audio and re-arm the output, so playback goes silent
+  /// immediately. Used on barge-in (#12) — the model queues audio ahead of
+  /// playback, so stopping the stream alone would keep playing what's buffered.
+  Future<void> flush();
+
   /// Stop playback and release the audio output.
   Future<void> stop();
 

--- a/lib/services/audio/pcm_sound_playback_service.dart
+++ b/lib/services/audio/pcm_sound_playback_service.dart
@@ -17,6 +17,14 @@ class PcmSoundPlaybackService implements AudioPlaybackService {
   }
 
   @override
+  Future<void> flush() async {
+    // Drop the queued PCM and re-arm the player so the next AI turn starts
+    // clean. release() clears the native buffer; setup() re-initializes it.
+    await FlutterPcmSound.release();
+    await FlutterPcmSound.setup(sampleRate: 24000, channelCount: 1);
+  }
+
+  @override
   Future<void> stop() async {
     await FlutterPcmSound.release();
   }

--- a/lib/services/call_session.dart
+++ b/lib/services/call_session.dart
@@ -22,6 +22,7 @@ class CallSession {
 
   StreamSubscription<Uint8List>? _audioOutputSub;
   StreamSubscription<Uint8List>? _recordingStreamSub;
+  StreamSubscription<void>? _interruptSub;
 
   CallSession({
     required this.recorder,
@@ -39,6 +40,12 @@ class CallSession {
       } catch (e) {
         debugPrint('Audio playback feed error: $e');
       }
+    });
+
+    // #12 barge-in: flush queued AI audio the moment Gemini reports the user
+    // spoke over it, so the AI goes silent immediately.
+    _interruptSub = bloc.interruptStream.listen((_) {
+      playback.flush();
     });
   }
 
@@ -71,6 +78,8 @@ class CallSession {
     await recorder.stop();
     _audioOutputSub?.cancel();
     _audioOutputSub = null;
+    _interruptSub?.cancel();
+    _interruptSub = null;
     await playback.stop();
   }
 
@@ -80,6 +89,8 @@ class CallSession {
     _recordingStreamSub = null;
     _audioOutputSub?.cancel();
     _audioOutputSub = null;
+    _interruptSub?.cancel();
+    _interruptSub = null;
     recorder.dispose();
     playback.dispose();
   }

--- a/lib/services/call_session.dart
+++ b/lib/services/call_session.dart
@@ -49,6 +49,14 @@ class CallSession {
         encoder: AudioEncoder.pcm16bits,
         sampleRate: 16000,
         numChannels: 1,
+        // #222: hardware acoustic echo cancellation. The VOICE_COMMUNICATION
+        // source engages the platform AEC (the mode phone calls use) so the
+        // mic doesn't pick up the AI's speaker output and loop it back.
+        echoCancel: true,
+        noiseSuppress: true,
+        androidConfig: AndroidRecordConfig(
+          audioSource: AndroidAudioSource.voiceCommunication,
+        ),
       ),
     );
     _recordingStreamSub = stream.listen((data) {

--- a/lib/services/call_session.dart
+++ b/lib/services/call_session.dart
@@ -44,8 +44,12 @@ class CallSession {
 
     // #12 barge-in: flush queued AI audio the moment Gemini reports the user
     // spoke over it, so the AI goes silent immediately.
-    _interruptSub = bloc.interruptStream.listen((_) {
-      playback.flush();
+    _interruptSub = bloc.interruptStream.listen((_) async {
+      try {
+        await playback.flush();
+      } catch (e) {
+        debugPrint('Audio playback flush error: $e');
+      }
     });
   }
 

--- a/lib/services/voice_call/gemini_live_service.dart
+++ b/lib/services/voice_call/gemini_live_service.dart
@@ -15,11 +15,23 @@ class Transcript {
   final String text;
   final bool isFinal;
 
+  /// True when this AI turn was cut short by the user speaking over it (#12).
+  /// The displayed text may be more than the user actually heard.
+  final bool interrupted;
+
   const Transcript({
     required this.speaker,
     required this.text,
     this.isFinal = true,
+    this.interrupted = false,
   });
+
+  Transcript copyWith({bool? isFinal, bool? interrupted}) => Transcript(
+    speaker: speaker,
+    text: text,
+    isFinal: isFinal ?? this.isFinal,
+    interrupted: interrupted ?? this.interrupted,
+  );
 }
 
 /// Wraps the Firebase AI Live API for bidirectional voice streaming.

--- a/lib/services/voice_call/gemini_live_service.dart
+++ b/lib/services/voice_call/gemini_live_service.dart
@@ -234,6 +234,9 @@ class GeminiLiveService {
       }
     } catch (e) {
       debugPrint('Gemini Live stream error: $e');
+      // #227: the socket is dead (e.g. WebSocket 1008). Null the session so
+      // sendAudio no-ops instead of throwing into the closed socket every tick.
+      _session = null;
       _emitState(GeminiLiveState.error);
       return;
     }
@@ -303,6 +306,11 @@ class GeminiLiveService {
   /// live session (the server interrupt arrives inside [_handleContent]).
   @visibleForTesting
   void handleInterruptForTest() => _emitInterrupt();
+
+  /// Test seam: simulate the receive loop nulling the session on a socket
+  /// close (#227), so [sendAudio] becomes a no-op.
+  @visibleForTesting
+  void markClosedForTest() => _session = null;
 
   void _handleToolCall(LiveServerToolCall toolCall) {
     if (toolCall.functionCalls == null) return;

--- a/lib/services/voice_call/gemini_live_service.dart
+++ b/lib/services/voice_call/gemini_live_service.dart
@@ -201,10 +201,6 @@ class GeminiLiveService {
       _modelTurnComplete = false;
       _measuring = true;
     }
-    // Anchor to the user's LATEST chunk so latency = end-of-speech -> AI audio
-    // (#223). Updating every chunk (not just the first) excludes the utterance
-    // duration from the measurement.
-    if (_measuring) _userLastChunkMs = _nowMs();
     _session!.sendAudioRealtime(InlineDataPart('audio/pcm', pcmData));
   }
 
@@ -314,6 +310,11 @@ class GeminiLiveService {
       final text = content.inputTranscription!.text!;
       final isFinal = content.inputTranscription!.finished == true;
       _log('User said: $text (final: $isFinal)');
+      // Anchor latency to the user's latest RECOGNIZED speech, not raw mic
+      // chunks — with the mic always open (#12), the last chunk sent is just
+      // "now", but input transcription only fires on actual speech, so it
+      // marks true end-of-speech (#223).
+      if (_measuring) _userLastChunkMs = _nowMs();
       _transcriptController.add(
         Transcript(speaker: Speaker.user, text: text, isFinal: isFinal),
       );
@@ -360,10 +361,12 @@ class GeminiLiveService {
   @visibleForTesting
   void markClosedForTest() => _session = null;
 
-  /// Test seam: record a user mic chunk for latency (#223), without a live
-  /// session. Mirrors the measurement path in [sendAudio].
+  /// Test seam: record recognized user speech for latency (#223), without a
+  /// live session. Mirrors the input-transcription path in [_handleContent].
   @visibleForTesting
   void noteUserAudioForTest() {
+    // sendAudio arms measuring on the first mic chunk; recognized speech then
+    // anchors the end-of-speech timestamp.
     if (_modelTurnComplete) {
       _modelTurnComplete = false;
       _measuring = true;

--- a/lib/services/voice_call/gemini_live_service.dart
+++ b/lib/services/voice_call/gemini_live_service.dart
@@ -43,9 +43,16 @@ class GeminiLiveService {
   final _transcriptController = StreamController<Transcript>.broadcast();
   final _toolCallController = StreamController<FunctionCall>.broadcast();
   final _stateController = StreamController<GeminiLiveState>.broadcast();
+  final _interruptController = StreamController<void>.broadcast();
 
   /// Audio chunks received from the model (PCM 24kHz 16-bit LE mono).
   Stream<Uint8List> get audioStream => _audioController.stream;
+
+  /// Fires when Gemini reports it cancelled its own generation because the
+  /// user spoke over the AI (server-side barge-in, #12). The UI must stop and
+  /// flush any buffered AI audio on this signal — the model generates audio
+  /// faster than it plays, so there is always more queued than the user heard.
+  Stream<void> get interruptStream => _interruptController.stream;
 
   /// Transcription updates (input and output).
   Stream<Transcript> get transcriptStream => _transcriptController.stream;
@@ -181,6 +188,7 @@ class GeminiLiveService {
     _toolCallController.close();
     _stateController.close();
     _latencyController.close();
+    _interruptController.close();
   }
 
   /// Start the receive loop for multi-turn conversations.
@@ -222,6 +230,12 @@ class GeminiLiveService {
   }
 
   void _handleContent(LiveServerContent content) {
+    // Server-side barge-in (#12): Gemini cancelled its generation because the
+    // user spoke over the AI. Surface it so the UI flushes buffered audio.
+    if (content.interrupted == true) {
+      _emitInterrupt();
+    }
+
     // Extract audio from model turn
     if (content.modelTurn != null) {
       for (final part in content.modelTurn!.parts) {
@@ -234,7 +248,7 @@ class GeminiLiveService {
             _measuring = false;
             debugPrint('Response latency: ${lastLatencyMs}ms');
           }
-          _audioController.add(part.bytes);
+          emitAudioChunk(part.bytes);
         }
       }
     }
@@ -257,6 +271,26 @@ class GeminiLiveService {
       );
     }
   }
+
+  /// Emit a received audio chunk to [audioStream], logging its size.
+  ///
+  /// The `[DYTTY] Audio chunk received: N bytes` line lets device logcat
+  /// confirm the model is actually sending audio (diagnostic from #222).
+  @visibleForTesting
+  void emitAudioChunk(Uint8List bytes) {
+    _log('Audio chunk received: ${bytes.length} bytes');
+    _audioController.add(bytes);
+  }
+
+  void _emitInterrupt() {
+    _log('Interrupted by user (server-side barge-in)');
+    _interruptController.add(null);
+  }
+
+  /// Test seam mirroring [emitAudioChunk] — drives [interruptStream] without a
+  /// live session (the server interrupt arrives inside [_handleContent]).
+  @visibleForTesting
+  void handleInterruptForTest() => _emitInterrupt();
 
   void _handleToolCall(LiveServerToolCall toolCall) {
     if (toolCall.functionCalls == null) return;

--- a/lib/services/voice_call/gemini_live_service.dart
+++ b/lib/services/voice_call/gemini_live_service.dart
@@ -348,6 +348,11 @@ class GeminiLiveService {
     _suppressTimer = Timer(postInterruptSuppression, () {
       _micSuppressed = false;
     });
+    // The interrupted turn ends here (no clean `turnComplete` will arrive), so
+    // re-arm measurement for the next turn — otherwise interrupted (contested)
+    // turns would be silently dropped from latency stats (#223).
+    _modelTurnComplete = true;
+    _measuring = false;
     _interruptController.add(null);
   }
 

--- a/lib/services/voice_call/gemini_live_service.dart
+++ b/lib/services/voice_call/gemini_live_service.dart
@@ -66,6 +66,22 @@ class GeminiLiveService {
   /// faster than it plays, so there is always more queued than the user heard.
   Stream<void> get interruptStream => _interruptController.stream;
 
+  /// How long to suppress mic-send after a barge-in (#12 Tier 1).
+  ///
+  /// On interrupt we've yielded the floor to the user, but the AI's speaker
+  /// audio keeps decaying for a few hundred ms (hardware + OS pipeline) and the
+  /// open mic captures it — Gemini then transcribes that echo as phantom user
+  /// input. Suppressing sends for this window absorbs the tail. Kept short so
+  /// the user's actual speech (which Gemini captured *before* the interrupt)
+  /// isn't lost. Deterministic suppression needs the raw API (#228).
+  static const postInterruptSuppression = Duration(milliseconds: 400);
+
+  Timer? _suppressTimer;
+  bool _micSuppressed = false;
+
+  /// Whether mic-send is currently suppressed by the post-interrupt window.
+  bool get isMicSuppressed => _micSuppressed;
+
   /// Transcription updates (input and output).
   Stream<Transcript> get transcriptStream => _transcriptController.stream;
 
@@ -119,6 +135,8 @@ class GeminiLiveService {
     _modelTurnComplete = true;
     _measuring = false;
     lastLatencyMs = null;
+    _suppressTimer?.cancel();
+    _micSuppressed = false;
 
     final effectivePrompt = systemPrompt ?? dailyCallSystemPrompt;
     final effectiveTools = tools ?? [call_tools.saveEntryDeclaration];
@@ -158,6 +176,8 @@ class GeminiLiveService {
   /// Audio format: 16-bit PCM, 16kHz, mono, little-endian.
   void sendAudio(Uint8List pcmData) {
     if (_session == null) return;
+    // Drop mic audio during the post-interrupt echo-tail window (#12 Tier 1).
+    if (_micSuppressed) return;
     if (_modelTurnComplete && !_measuring) {
       _latencyStopwatch.reset();
       _latencyStopwatch.start();
@@ -195,6 +215,7 @@ class GeminiLiveService {
   }
 
   void dispose() {
+    _suppressTimer?.cancel();
     _audioController.close();
     _transcriptController.close();
     _toolCallController.close();
@@ -299,6 +320,13 @@ class GeminiLiveService {
 
   void _emitInterrupt() {
     _log('Interrupted by user (server-side barge-in)');
+    // Yield the floor: suppress mic-send so the AI's decaying speaker tail
+    // isn't streamed back and transcribed as phantom user input (#12 Tier 1).
+    _micSuppressed = true;
+    _suppressTimer?.cancel();
+    _suppressTimer = Timer(postInterruptSuppression, () {
+      _micSuppressed = false;
+    });
     _interruptController.add(null);
   }
 

--- a/lib/services/voice_call/gemini_live_service.dart
+++ b/lib/services/voice_call/gemini_live_service.dart
@@ -102,11 +102,29 @@ class GeminiLiveService {
     _stateController.add(state);
   }
 
-  /// High-resolution monotonic timer for latency measurement.
-  final Stopwatch _latencyStopwatch = Stopwatch();
+  /// Monotonic clock for latency measurement (injectable for tests).
+  ///
+  /// Returns elapsed milliseconds from an arbitrary fixed origin.
+  final int Function() _nowMs;
+
   final LatencyTracker _latencyTracker = LatencyTracker();
   bool _modelTurnComplete = true;
   bool _measuring = false;
+
+  /// Timestamp of the user's most recent mic chunk this turn (#223).
+  ///
+  /// Latency is measured end-of-user-speech -> first-AI-audio, so we anchor to
+  /// the LATEST user chunk (updated on every send), not the first. Measuring
+  /// from the first chunk inflates latency by the whole utterance + Gemini's
+  /// VAD silence wait.
+  int? _userLastChunkMs;
+
+  /// [nowMs] is an injectable monotonic clock (ms) for deterministic latency
+  /// tests; defaults to a process-wide stopwatch.
+  GeminiLiveService({int Function()? nowMs})
+    : _nowMs = nowMs ?? (() => _defaultClock.elapsedMilliseconds);
+
+  static final Stopwatch _defaultClock = Stopwatch()..start();
 
   final _latencyController = StreamController<int>.broadcast();
 
@@ -134,6 +152,7 @@ class GeminiLiveService {
     _latencyTracker.reset();
     _modelTurnComplete = true;
     _measuring = false;
+    _userLastChunkMs = null;
     lastLatencyMs = null;
     _suppressTimer?.cancel();
     _micSuppressed = false;
@@ -178,12 +197,14 @@ class GeminiLiveService {
     if (_session == null) return;
     // Drop mic audio during the post-interrupt echo-tail window (#12 Tier 1).
     if (_micSuppressed) return;
-    if (_modelTurnComplete && !_measuring) {
-      _latencyStopwatch.reset();
-      _latencyStopwatch.start();
+    if (_modelTurnComplete) {
       _modelTurnComplete = false;
       _measuring = true;
     }
+    // Anchor to the user's LATEST chunk so latency = end-of-speech -> AI audio
+    // (#223). Updating every chunk (not just the first) excludes the utterance
+    // duration from the measurement.
+    if (_measuring) _userLastChunkMs = _nowMs();
     _session!.sendAudioRealtime(InlineDataPart('audio/pcm', pcmData));
   }
 
@@ -276,9 +297,8 @@ class GeminiLiveService {
     if (content.modelTurn != null) {
       for (final part in content.modelTurn!.parts) {
         if (part is InlineDataPart && part.mimeType.startsWith('audio/')) {
-          if (_measuring) {
-            _latencyStopwatch.stop();
-            lastLatencyMs = _latencyStopwatch.elapsedMilliseconds;
+          if (_measuring && _userLastChunkMs != null) {
+            lastLatencyMs = _nowMs() - _userLastChunkMs!;
             _latencyTracker.add(lastLatencyMs!);
             _latencyController.add(lastLatencyMs!);
             _measuring = false;
@@ -339,6 +359,28 @@ class GeminiLiveService {
   /// close (#227), so [sendAudio] becomes a no-op.
   @visibleForTesting
   void markClosedForTest() => _session = null;
+
+  /// Test seam: record a user mic chunk for latency (#223), without a live
+  /// session. Mirrors the measurement path in [sendAudio].
+  @visibleForTesting
+  void noteUserAudioForTest() {
+    if (_modelTurnComplete) {
+      _modelTurnComplete = false;
+      _measuring = true;
+    }
+    if (_measuring) _userLastChunkMs = _nowMs();
+  }
+
+  /// Test seam: record the AI's first audio chunk for latency (#223). Mirrors
+  /// the measurement path in [_handleContent].
+  @visibleForTesting
+  void noteAiAudioForTest() {
+    if (_measuring && _userLastChunkMs != null) {
+      lastLatencyMs = _nowMs() - _userLastChunkMs!;
+      _latencyTracker.add(lastLatencyMs!);
+      _measuring = false;
+    }
+  }
 
   void _handleToolCall(LiveServerToolCall toolCall) {
     if (toolCall.functionCalls == null) return;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -282,7 +282,7 @@ packages:
     source: hosted
     version: "2.0.8"
   fake_async:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: fake_async
       sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dev_dependencies:
   build_runner: ^2.4.14
   bloc_test: ^10.0.0
   mocktail: ^1.0.4
+  fake_async: ^1.3.1
   patrol: ^4.3.0
   patrol_finders: ^3.1.0
   yaml: ^3.1.3

--- a/test/fakes/fake_audio_playback_service.dart
+++ b/test/fakes/fake_audio_playback_service.dart
@@ -31,6 +31,11 @@ class FakeAudioPlaybackService implements AudioPlaybackService {
   }
 
   @override
+  Future<void> flush() async {
+    calls.add('flush');
+  }
+
+  @override
   Future<void> stop() async {
     calls.add('stop');
   }

--- a/test/features/category_detail/review_call_controller_test.dart
+++ b/test/features/category_detail/review_call_controller_test.dart
@@ -147,6 +147,9 @@ void main() {
       when(
         () => mockVoiceBloc.audioOutputStream,
       ).thenAnswer((_) => const Stream<Uint8List>.empty());
+      when(
+        () => mockVoiceBloc.interruptStream,
+      ).thenAnswer((_) => const Stream<void>.empty());
 
       // Cleanup stubs for dispose
       when(() => mockRecorder.dispose()).thenAnswer((_) async {});
@@ -230,6 +233,9 @@ void main() {
       when(
         () => mockVoiceBloc.audioOutputStream,
       ).thenAnswer((_) => const Stream<Uint8List>.empty());
+      when(
+        () => mockVoiceBloc.interruptStream,
+      ).thenAnswer((_) => const Stream<void>.empty());
 
       // Set up endCall mocks
       when(() => mockRecorder.stop()).thenAnswer((_) async => null);
@@ -296,6 +302,9 @@ void main() {
       when(
         () => mockVoiceBloc.audioOutputStream,
       ).thenAnswer((_) => const Stream<Uint8List>.empty());
+      when(
+        () => mockVoiceBloc.interruptStream,
+      ).thenAnswer((_) => const Stream<void>.empty());
 
       // endCall mocks (called after connect failure)
       when(() => mockRecorder.stop()).thenAnswer((_) async => null);
@@ -364,6 +373,9 @@ void main() {
       when(
         () => mockVoiceBloc.audioOutputStream,
       ).thenAnswer((_) => const Stream<Uint8List>.empty());
+      when(
+        () => mockVoiceBloc.interruptStream,
+      ).thenAnswer((_) => const Stream<void>.empty());
 
       // Cleanup mocks
       when(() => mockRecorder.dispose()).thenAnswer((_) async {});

--- a/test/features/voice_call/voice_call_bloc_prompt_test.dart
+++ b/test/features/voice_call/voice_call_bloc_prompt_test.dart
@@ -23,6 +23,9 @@ void main() {
       () => mockService.latencyStream,
     ).thenAnswer((_) => const Stream.empty());
     when(
+      () => mockService.interruptStream,
+    ).thenAnswer((_) => const Stream.empty());
+    when(
       () => mockService.connect(
         systemPrompt: any(named: 'systemPrompt'),
         tools: any(named: 'tools'),

--- a/test/features/voice_call/voice_call_bloc_test.dart
+++ b/test/features/voice_call/voice_call_bloc_test.dart
@@ -408,29 +408,49 @@ void main() {
   });
 
   group('TranscriptReceived with aggregation', () {
+    // #123: Gemini streams transcript as incremental DELTAS, not cumulative
+    // snapshots (device-confirmed: "Hey" -> "," -> " I" -> " had"). Deltas from
+    // the same speaker must be APPENDED, not replaced — replacing left the
+    // bubble showing only the last fragment (truncated speech).
     blocTest<VoiceCallBloc, VoiceCallState>(
-      'partial from same speaker replaces last bubble (length stays 1)',
+      'partials from same speaker append into one bubble (#123)',
       build: () => buildBloc(),
       seed: () => const VoiceCallState(status: VoiceCallStatus.active),
       act: (bloc) {
         bloc.add(
           const TranscriptReceived(
-            Transcript(speaker: Speaker.user, text: 'Hel', isFinal: false),
+            Transcript(speaker: Speaker.user, text: 'Hey', isFinal: false),
           ),
         );
         bloc.add(
           const TranscriptReceived(
-            Transcript(speaker: Speaker.user, text: 'Hello', isFinal: false),
+            Transcript(speaker: Speaker.user, text: ', I had', isFinal: false),
+          ),
+        );
+        bloc.add(
+          const TranscriptReceived(
+            Transcript(
+              speaker: Speaker.user,
+              text: ' a good day.',
+              isFinal: false,
+            ),
           ),
         );
       },
       expect: () => [
         isA<VoiceCallState>()
             .having((s) => s.transcripts.length, 'length', 1)
-            .having((s) => s.transcripts.last.text, 'text', 'Hel'),
+            .having((s) => s.transcripts.last.text, 'text', 'Hey'),
         isA<VoiceCallState>()
             .having((s) => s.transcripts.length, 'length', 1)
-            .having((s) => s.transcripts.last.text, 'text', 'Hello'),
+            .having((s) => s.transcripts.last.text, 'text', 'Hey, I had'),
+        isA<VoiceCallState>()
+            .having((s) => s.transcripts.length, 'length', 1)
+            .having(
+              (s) => s.transcripts.last.text,
+              'text',
+              'Hey, I had a good day.',
+            ),
       ],
     );
 

--- a/test/features/voice_call/voice_call_bloc_test.dart
+++ b/test/features/voice_call/voice_call_bloc_test.dart
@@ -35,6 +35,7 @@ void main() {
   late StreamController<GeminiLiveState> stateController;
   late StreamController<Uint8List> audioController;
   late StreamController<int> latencyController;
+  late StreamController<void> interruptController;
 
   setUpAll(() {
     registerFallbackValue(
@@ -55,6 +56,7 @@ void main() {
     stateController = StreamController<GeminiLiveState>.broadcast();
     audioController = StreamController<Uint8List>.broadcast();
     latencyController = StreamController<int>.broadcast();
+    interruptController = StreamController<void>.broadcast();
 
     when(
       () => mockService.transcriptStream,
@@ -71,6 +73,9 @@ void main() {
     when(
       () => mockService.latencyStream,
     ).thenAnswer((_) => latencyController.stream);
+    when(
+      () => mockService.interruptStream,
+    ).thenAnswer((_) => interruptController.stream);
     when(() => mockService.latencyP50).thenReturn(null);
     when(() => mockService.latencyP95).thenReturn(null);
     when(() => mockService.connect()).thenAnswer((_) async {});
@@ -88,6 +93,7 @@ void main() {
     stateController.close();
     audioController.close();
     latencyController.close();
+    interruptController.close();
   });
 
   VoiceCallBloc buildBloc({
@@ -934,6 +940,32 @@ void main() {
       final bloc = buildBloc();
       expect(bloc.recordedAudio, isNull);
       bloc.close();
+    });
+
+    // #12: on barge-in, the in-flight AI transcript holds text the user never
+    // heard (audio is generated ahead of playback). Mark it interrupted so the
+    // call history / summary reflect what was actually said.
+    test('marks the in-flight AI transcript interrupted on barge-in', () async {
+      final bloc = buildBloc();
+      bloc.add(const StartCall());
+      await Future<void>.delayed(Duration.zero);
+
+      transcriptController.add(
+        const Transcript(
+          speaker: Speaker.ai,
+          text: 'I think you should',
+          isFinal: false,
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      interruptController.add(null);
+      await Future<void>.delayed(Duration.zero);
+
+      final last = bloc.state.transcripts.last;
+      expect(last.interrupted, isTrue);
+      expect(last.isFinal, isTrue);
+      await bloc.close();
     });
 
     // #12 open-mic: the mic streams continuously, INCLUDING while the AI is

--- a/test/features/voice_call/voice_call_bloc_test.dart
+++ b/test/features/voice_call/voice_call_bloc_test.dart
@@ -745,6 +745,24 @@ void main() {
       ],
     );
 
+    // #227 regression: after an error, the per-second elapsed timer must not
+    // revert the status back to `active` (which would mask the dropped call and
+    // strand the user in a fake-active session against a dead socket).
+    blocTest<VoiceCallBloc, VoiceCallState>(
+      'session tick after error keeps the call in error (not active)',
+      build: () => buildBloc(),
+      act: (bloc) async {
+        bloc.add(const StartCall()); // starts the elapsed timer
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        bloc.add(const ServiceStateChanged(GeminiLiveState.error));
+        // Wait past one timer tick (1s) to let any stray tick fire.
+        await Future<void>.delayed(const Duration(milliseconds: 1200));
+      },
+      verify: (bloc) {
+        expect(bloc.state.status, VoiceCallStatus.error);
+      },
+    );
+
     blocTest<VoiceCallBloc, VoiceCallState>(
       'idle state during active call triggers EndCall',
       build: () => buildBloc(),

--- a/test/features/voice_call/voice_call_bloc_test.dart
+++ b/test/features/voice_call/voice_call_bloc_test.dart
@@ -936,6 +936,23 @@ void main() {
       bloc.close();
     });
 
+    // #12 open-mic: the mic streams continuously, INCLUDING while the AI is
+    // speaking — Gemini's server-side VAD needs that audio to detect barge-in.
+    // The echo loop is prevented by platform AEC + flushing playback on the
+    // interrupt signal, not by gating the mic (device-validated 2026-06-15).
+    test('forwards mic audio continuously, including during AI speech', () {
+      final bloc = buildBloc();
+      final data = Uint8List.fromList([10, 20, 30]);
+
+      bloc.sendAudio(data);
+      bloc.sendAudio(data);
+
+      verify(() => mockService.sendAudio(data)).called(2);
+      expect(bloc.recordedAudio, isNotNull);
+      expect(bloc.recordedAudio!.length, 6);
+      bloc.close();
+    });
+
     test('does not forward to service when muted', () {
       final bloc = buildBloc();
       // Manually set muted state by adding ToggleMute

--- a/test/features/voice_call/voice_call_bloc_test.dart
+++ b/test/features/voice_call/voice_call_bloc_test.dart
@@ -1006,6 +1006,49 @@ void main() {
       await bloc.close();
     });
 
+    // #12 open-mic regression: because the mic streams continuously, the user's
+    // partial transcript can be appended AFTER the AI bubble but BEFORE Gemini's
+    // interrupt signal arrives. The AI bubble is then second-to-last, so checking
+    // only `current.last` would never finalize it. Find the last AI bubble.
+    test(
+      'marks the AI transcript interrupted even when a user partial follows it',
+      () async {
+        final bloc = buildBloc();
+        bloc.add(const StartCall());
+        await Future<void>.delayed(Duration.zero);
+
+        // AI is mid-turn.
+        transcriptController.add(
+          const Transcript(
+            speaker: Speaker.ai,
+            text: 'I think you should',
+            isFinal: false,
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        // User starts speaking — their partial lands before the interrupt.
+        transcriptController.add(
+          const Transcript(speaker: Speaker.user, text: 'wait', isFinal: false),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        interruptController.add(null);
+        await Future<void>.delayed(Duration.zero);
+
+        final aiBubble = bloc.state.transcripts.firstWhere(
+          (t) => t.speaker == Speaker.ai,
+        );
+        expect(
+          aiBubble.interrupted,
+          isTrue,
+          reason: 'the AI bubble must be finalized even when not last',
+        );
+        expect(aiBubble.isFinal, isTrue);
+        await bloc.close();
+      },
+    );
+
     // #12 open-mic: the mic streams continuously, INCLUDING while the AI is
     // speaking — Gemini's server-side VAD needs that audio to detect barge-in.
     // The echo loop is prevented by platform AEC + flushing playback on the

--- a/test/services/call_session_test.dart
+++ b/test/services/call_session_test.dart
@@ -119,6 +119,36 @@ void main() {
 
         await controller.close();
       });
+
+      // #222: AI talks to itself in a loop because the mic picks up the
+      // speaker output (the AI's voice) with no echo cancellation. Enabling
+      // hardware AEC via the VOICE_COMMUNICATION audio source + echoCancel /
+      // noiseSuppress flags is the proper fix.
+      test('requests echo cancellation to prevent AI self-feedback', () async {
+        final controller = StreamController<Uint8List>();
+        when(
+          () => mockRecorder.startStream(any()),
+        ).thenAnswer((_) async => controller.stream);
+
+        await session.startRecording();
+
+        verify(
+          () => mockRecorder.startStream(
+            any(
+              that: isA<RecordConfig>()
+                  .having((c) => c.echoCancel, 'echoCancel', isTrue)
+                  .having((c) => c.noiseSuppress, 'noiseSuppress', isTrue)
+                  .having(
+                    (c) => c.androidConfig.audioSource,
+                    'androidConfig.audioSource',
+                    AndroidAudioSource.voiceCommunication,
+                  ),
+            ),
+          ),
+        ).called(1);
+
+        await controller.close();
+      });
     });
 
     group('stop', () {

--- a/test/services/call_session_test.dart
+++ b/test/services/call_session_test.dart
@@ -41,6 +41,11 @@ void main() {
     mockPlayback = MockAudioPlaybackService();
     mockBloc = MockVoiceCallBloc();
 
+    // Default: no interrupts. Individual tests override with their own stream.
+    when(
+      () => mockBloc.interruptStream,
+    ).thenAnswer((_) => const Stream<void>.empty());
+
     session = CallSession(
       recorder: mockRecorder,
       playback: mockPlayback,
@@ -87,6 +92,32 @@ void main() {
         verify(() => mockPlayback.feed(audioData)).called(1);
 
         await controller.close();
+      });
+    });
+
+    group('interrupt', () {
+      // #12: on Gemini's barge-in signal, the buffered AI audio (which runs
+      // ahead of playback) must be flushed so the AI goes silent immediately.
+      test('flushes playback when the bloc interruptStream fires', () async {
+        final interrupts = StreamController<void>();
+        addTearDown(interrupts.close);
+
+        when(
+          () => mockPlayback.init(sampleRate: 24000, channels: 1),
+        ).thenAnswer((_) async {});
+        when(
+          () => mockBloc.audioOutputStream,
+        ).thenAnswer((_) => const Stream<Uint8List>.empty());
+        when(
+          () => mockBloc.interruptStream,
+        ).thenAnswer((_) => interrupts.stream);
+        when(() => mockPlayback.flush()).thenAnswer((_) async {});
+
+        await session.initPlayback();
+        interrupts.add(null);
+        await Future<void>.delayed(Duration.zero);
+
+        verify(() => mockPlayback.flush()).called(1);
       });
     });
 

--- a/test/services/voice_call/gemini_live_service_log_test.dart
+++ b/test/services/voice_call/gemini_live_service_log_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:dytty/services/voice_call/gemini_live_service.dart';
+
+/// Diagnostic-logging contract for issue #222: "daily call AI audio not heard
+/// — only transcript renders."
+///
+/// `_handleContent` already logs "AI said: ..." for output transcription, but
+/// logs nothing when an audio chunk arrives. That gap makes it impossible to
+/// tell — from a device logcat — whether the model is sending audio at all
+/// (chunks never arrive) versus the native player swallowing it (chunks arrive
+/// but produce no sound). These tests pin the missing log line so the on-device
+/// repro becomes a binary fork in the road.
+void main() {
+  late List<String> logs;
+  late DebugPrintCallback originalDebugPrint;
+
+  setUp(() {
+    logs = [];
+    originalDebugPrint = debugPrint;
+    debugPrint = (String? message, {int? wrapWidth}) {
+      if (message != null) logs.add(message);
+    };
+  });
+
+  tearDown(() {
+    debugPrint = originalDebugPrint;
+  });
+
+  group('[DYTTY] audio chunk logging (#222)', () {
+    test('logs byte count when an audio chunk is emitted', () {
+      final service = GeminiLiveService();
+      addTearDown(service.dispose);
+
+      service.emitAudioChunk(Uint8List(960));
+
+      expect(
+        logs.any((l) => l.contains('[DYTTY] Audio chunk received: 960 bytes')),
+        isTrue,
+        reason:
+            'an arriving audio chunk must be logged so device logcat can '
+            'distinguish "model sent no audio" from "player produced no sound"',
+      );
+    });
+
+    test('still forwards the chunk to audioStream', () async {
+      final service = GeminiLiveService();
+      addTearDown(service.dispose);
+
+      final received = <Uint8List>[];
+      service.audioStream.listen(received.add);
+
+      final chunk = Uint8List.fromList([1, 2, 3, 4]);
+      service.emitAudioChunk(chunk);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(received, hasLength(1));
+      expect(received.first, chunk);
+    });
+
+    test('logs the actual byte count for each chunk size', () {
+      final service = GeminiLiveService();
+      addTearDown(service.dispose);
+
+      service.emitAudioChunk(Uint8List(4));
+      service.emitAudioChunk(Uint8List(2048));
+
+      expect(
+        logs.any((l) => l.contains('[DYTTY] Audio chunk received: 4 bytes')),
+        isTrue,
+      );
+      expect(
+        logs.any((l) => l.contains('[DYTTY] Audio chunk received: 2048 bytes')),
+        isTrue,
+      );
+    });
+  });
+
+  // #12 barge-in: open-mic architecture. Gemini runs server-side VAD and sets
+  // LiveServerContent.interrupted == true when the user speaks over the AI.
+  // The service surfaces that as interruptStream so the UI can stop + flush
+  // buffered AI audio. (Validated on device 2026-06-15: the signal fires.)
+  group('[DYTTY] interrupt signal (#12)', () {
+    test('emits on interruptStream when an interrupt is handled', () async {
+      final service = GeminiLiveService();
+      addTearDown(service.dispose);
+
+      var count = 0;
+      service.interruptStream.listen((_) => count++);
+
+      service.handleInterruptForTest();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(count, 1);
+    });
+
+    test('logs the interruption for device observability', () {
+      final service = GeminiLiveService();
+      addTearDown(service.dispose);
+
+      service.handleInterruptForTest();
+
+      expect(
+        logs.any((l) => l.contains('[DYTTY] Interrupted by user')),
+        isTrue,
+      );
+    });
+  });
+}

--- a/test/services/voice_call/gemini_live_service_log_test.dart
+++ b/test/services/voice_call/gemini_live_service_log_test.dart
@@ -146,6 +146,46 @@ void main() {
     });
   });
 
+  // #223: latency must be measured end-of-user-speech -> first-AI-audio, NOT
+  // from the user's first chunk (which inflates it by the whole utterance +
+  // Gemini's VAD wait). The clock anchors to the LATEST user chunk.
+  group('latency measurement (#223)', () {
+    test('measures from the user last chunk, not the first', () {
+      var now = 0;
+      final service = GeminiLiveService(nowMs: () => now);
+      addTearDown(service.dispose);
+
+      now = 1000; // user starts speaking
+      service.noteUserAudioForTest();
+      now = 1700; // ...still speaking (700ms of utterance)
+      service.noteUserAudioForTest();
+      now = 2000; // last user chunk (end of speech)
+      service.noteUserAudioForTest();
+
+      now = 3635; // AI's first audio arrives
+      service.noteAiAudioForTest();
+
+      // 3635 - 2000 = 1635 (end-of-speech -> AI audio), NOT 3635 - 1000 = 2635.
+      expect(service.lastLatencyMs, 1635);
+    });
+
+    test('p50 reflects the corrected per-turn latency', () {
+      var now = 0;
+      final service = GeminiLiveService(nowMs: () => now);
+      addTearDown(service.dispose);
+
+      // One full turn: speak at 500, last chunk 1000, AI audio at 2600 -> 1600.
+      now = 500;
+      service.noteUserAudioForTest();
+      now = 1000;
+      service.noteUserAudioForTest();
+      now = 2600;
+      service.noteAiAudioForTest();
+
+      expect(service.latencyP50, 1600);
+    });
+  });
+
   // #227: when the Gemini WebSocket closes (e.g. 1008 mid-session), the receive
   // loop must null the session so sendAudio stops firing into the dead socket
   // (which previously threw an unhandled exception every mic tick — the "lock").

--- a/test/services/voice_call/gemini_live_service_log_test.dart
+++ b/test/services/voice_call/gemini_live_service_log_test.dart
@@ -1,3 +1,4 @@
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -105,6 +106,43 @@ void main() {
         logs.any((l) => l.contains('[DYTTY] Interrupted by user')),
         isTrue,
       );
+    });
+
+    // #12 Tier 1 (ghost-input fix): after a barge-in we've yielded the floor to
+    // the user, so the AI's decaying speaker tail must NOT be streamed back as
+    // input (Gemini transcribes it as phantom user speech). Suppress mic-send
+    // for a short window after the interrupt — the "ASR gating during cancel
+    // window" layer validated across LiveKit / Pipecat / Reflection.app.
+    test('suppresses mic-send for a window after an interrupt', () {
+      fakeAsync((async) {
+        final service = GeminiLiveService();
+        addTearDown(service.dispose);
+
+        expect(
+          service.isMicSuppressed,
+          isFalse,
+          reason: 'not suppressed before any interrupt',
+        );
+
+        service.handleInterruptForTest();
+        expect(
+          service.isMicSuppressed,
+          isTrue,
+          reason: 'the echo tail window opens on interrupt',
+        );
+
+        // Still within the window.
+        async.elapse(GeminiLiveService.postInterruptSuppression * 0.5);
+        expect(service.isMicSuppressed, isTrue);
+
+        // Window elapsed — mic reopens.
+        async.elapse(GeminiLiveService.postInterruptSuppression);
+        expect(
+          service.isMicSuppressed,
+          isFalse,
+          reason: 'the user keeps the floor once the tail has decayed',
+        );
+      });
     });
   });
 

--- a/test/services/voice_call/gemini_live_service_log_test.dart
+++ b/test/services/voice_call/gemini_live_service_log_test.dart
@@ -107,4 +107,20 @@ void main() {
       );
     });
   });
+
+  // #227: when the Gemini WebSocket closes (e.g. 1008 mid-session), the receive
+  // loop must null the session so sendAudio stops firing into the dead socket
+  // (which previously threw an unhandled exception every mic tick — the "lock").
+  group('session close recovery (#227)', () {
+    test('sendAudio is a no-op once the session is marked closed', () {
+      final service = GeminiLiveService();
+      addTearDown(service.dispose);
+
+      service.markClosedForTest();
+
+      // Must not throw, and the session is no longer connected.
+      service.sendAudio(Uint8List(4));
+      expect(service.isConnected, isFalse);
+    });
+  });
 }

--- a/test/services/voice_call/gemini_live_service_log_test.dart
+++ b/test/services/voice_call/gemini_live_service_log_test.dart
@@ -184,6 +184,32 @@ void main() {
 
       expect(service.latencyP50, 1600);
     });
+
+    // #223 + #12: a barge-in ends the turn without a clean `turnComplete`, so
+    // the interrupt must re-arm measurement — else the NEXT turn (and every
+    // turn after an interrupt) is silently dropped from latency stats.
+    test('re-arms measurement after an interrupt so the next turn counts', () {
+      var now = 0;
+      final service = GeminiLiveService(nowMs: () => now);
+      addTearDown(service.dispose);
+
+      // Turn 1 completes via interrupt (no turnComplete).
+      now = 100;
+      service.noteUserAudioForTest();
+      now = 700;
+      service.noteAiAudioForTest(); // 600ms
+      service.handleInterruptForTest(); // re-arms
+
+      // Turn 2 must be measured.
+      now = 2000;
+      service.noteUserAudioForTest();
+      now = 3500;
+      service.noteAiAudioForTest(); // 1500ms
+
+      // Both turns recorded (p95 picks the larger).
+      expect(service.latencyP95, 1500);
+      expect(service.lastLatencyMs, 1500);
+    });
   });
 
   // #227: when the Gemini WebSocket closes (e.g. 1008 mid-session), the receive

--- a/tools/acoustic-harness/latency.py
+++ b/tools/acoustic-harness/latency.py
@@ -62,23 +62,50 @@ def analyze_turns(log_path: str) -> list[dict]:
     """
     turns = []
     last_user_ms = None
+    ai_first_token_ms = None  # first "AI said" after end-of-speech, before audio
     measuring = False  # have we seen user speech since the last AI audio?
 
     for ts, msg in _events(log_path):
         if msg.startswith("User said"):
             last_user_ms = ts
             measuring = True
-        elif msg.startswith("Audio chunk received") and measuring and last_user_ms is not None:
+            ai_first_token_ms = None  # reset for this turn
+        elif msg.startswith("AI said") and measuring and ai_first_token_ms is None:
+            # First AI transcript token = the model has started responding,
+            # before audio is encoded/sent. Splits the latency into "Gemini
+            # processing" vs "first-token -> first-audio".
+            ai_first_token_ms = ts
+        elif (
+            msg.startswith("Audio chunk received")
+            and measuring
+            and last_user_ms is not None
+        ):
             turns.append(
                 {
                     "user_last_ms": last_user_ms,
+                    "ai_first_token_ms": ai_first_token_ms,
                     "ai_first_audio_ms": ts,
                     "latency_ms": ts - last_user_ms,
+                    "processing_ms": (
+                        ai_first_token_ms - last_user_ms
+                        if ai_first_token_ms is not None
+                        else None
+                    ),
+                    "token_to_audio_ms": (
+                        ts - ai_first_token_ms
+                        if ai_first_token_ms is not None
+                        else None
+                    ),
                 }
             )
             measuring = False  # wait for the next user turn before measuring again
 
     return turns
+
+
+def _mean(values) -> int | None:
+    vals = [v for v in values if v is not None]
+    return round(sum(vals) / len(vals)) if vals else None
 
 
 def summarize(turns: list[dict]) -> dict:
@@ -93,6 +120,9 @@ def summarize(turns: list[dict]) -> dict:
         "max_ms": lat[-1],
         "median_ms": lat[n // 2],
         "mean_ms": round(sum(lat) / n),
+        # Breakdown means (None when no AI-token was logged before audio).
+        "mean_processing_ms": _mean(t["processing_ms"] for t in turns),
+        "mean_token_to_audio_ms": _mean(t["token_to_audio_ms"] for t in turns),
     }
 
 
@@ -111,15 +141,29 @@ def main() -> None:
 
     print("=== Daily-call latency (end-of-speech -> first-AI-audio) ===\n")
     for i, t in enumerate(turns, 1):
-        print(f"  turn {i}: {t['latency_ms']} ms")
+        proc = t["processing_ms"]
+        t2a = t["token_to_audio_ms"]
+        if proc is not None:
+            print(
+                f"  turn {i}: {t['latency_ms']} ms total = "
+                f"{proc} ms Gemini-processing (end-speech -> first token) + "
+                f"{t2a} ms first-token -> first-audio"
+            )
+        else:
+            print(f"  turn {i}: {t['latency_ms']} ms total")
     print()
     if stats["turns"]:
         print(
             f"  {stats['turns']} turns | "
-            f"median {stats['median_ms']} ms | "
-            f"mean {stats['mean_ms']} ms | "
+            f"median {stats['median_ms']} ms | mean {stats['mean_ms']} ms | "
             f"min {stats['min_ms']} | max {stats['max_ms']}"
         )
+        if stats["mean_processing_ms"] is not None:
+            print(
+                f"  breakdown (mean): "
+                f"{stats['mean_processing_ms']} ms processing + "
+                f"{stats['mean_token_to_audio_ms']} ms token->audio"
+            )
     else:
         print("  no complete turns found in log")
     sys.exit(0)

--- a/tools/acoustic-harness/latency.py
+++ b/tools/acoustic-harness/latency.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Measure true conversational latency from a daily-call session log (#223).
+
+The in-app stopwatch (gemini_live_service.dart) starts on the user's FIRST mic
+chunk and stops on the AI's first audio chunk — so it includes the entire user
+utterance plus Gemini's server-side VAD silence wait. That is NOT latency by any
+industry definition; it's "total wall-clock the user waits, including their own
+talking."
+
+The correct, comparable metric is end-of-user-speech -> first-AI-audio. Both
+events are timestamped on the device's single logcat clock, so no cross-device
+synchronization is needed (unlike measuring the laptop's playback clock).
+
+This analyzer parses a `[DYTTY]`-tagged session log and reports, per turn:
+  user_last_ms       — timestamp of the user's last "User said" before the response
+  ai_first_audio_ms  — timestamp of the AI's first "Audio chunk received"
+  latency_ms         — ai_first_audio_ms - user_last_ms  (the real number)
+
+Usage:
+    python latency.py --log session.log
+    python latency.py --log session.log --json
+"""
+
+import argparse
+import json
+import re
+import sys
+
+# 06-15 17:50:44.816 I/flutter ( 7245): [DYTTY] User said: ...
+_LINE = re.compile(
+    r"^(?P<ts>\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3})\b.*\[DYTTY\] (?P<msg>.*)$"
+)
+_TS = re.compile(r"\d{2}-\d{2} (\d{2}):(\d{2}):(\d{2})\.(\d{3})")
+
+
+def parse_timestamp(ts: str) -> int:
+    """Logcat 'MM-DD HH:MM:SS.mmm' -> milliseconds within the day.
+
+    Day rollover is not handled (a single call never spans midnight).
+    """
+    m = _TS.search(ts)
+    if not m:
+        raise ValueError(f"unparseable timestamp: {ts!r}")
+    h, mi, s, ms = (int(g) for g in m.groups())
+    return ((h * 60 + mi) * 60 + s) * 1000 + ms
+
+
+def _events(log_path: str):
+    """Yield (timestamp_ms, message) for every [DYTTY] line, in order."""
+    with open(log_path, encoding="utf-8", errors="replace") as f:
+        for line in f:
+            m = _LINE.match(line.strip())
+            if m:
+                yield parse_timestamp(m.group("ts")), m.group("msg")
+
+
+def analyze_turns(log_path: str) -> list[dict]:
+    """Compute per-turn end-of-speech -> first-AI-audio latency.
+
+    A turn = a run of "User said" lines followed by the first "Audio chunk
+    received". The user's last "User said" before that chunk is end-of-speech.
+    """
+    turns = []
+    last_user_ms = None
+    measuring = False  # have we seen user speech since the last AI audio?
+
+    for ts, msg in _events(log_path):
+        if msg.startswith("User said"):
+            last_user_ms = ts
+            measuring = True
+        elif msg.startswith("Audio chunk received") and measuring and last_user_ms is not None:
+            turns.append(
+                {
+                    "user_last_ms": last_user_ms,
+                    "ai_first_audio_ms": ts,
+                    "latency_ms": ts - last_user_ms,
+                }
+            )
+            measuring = False  # wait for the next user turn before measuring again
+
+    return turns
+
+
+def summarize(turns: list[dict]) -> dict:
+    """Aggregate stats over all turns."""
+    if not turns:
+        return {"turns": 0}
+    lat = sorted(t["latency_ms"] for t in turns)
+    n = len(lat)
+    return {
+        "turns": n,
+        "min_ms": lat[0],
+        "max_ms": lat[-1],
+        "median_ms": lat[n // 2],
+        "mean_ms": round(sum(lat) / n),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--log", required=True, help="Path to the session log")
+    parser.add_argument("--json", action="store_true", help="Emit JSON")
+    args = parser.parse_args()
+
+    turns = analyze_turns(args.log)
+    stats = summarize(turns)
+
+    if args.json:
+        print(json.dumps({"turns": turns, "summary": stats}, indent=2))
+        return
+
+    print("=== Daily-call latency (end-of-speech -> first-AI-audio) ===\n")
+    for i, t in enumerate(turns, 1):
+        print(f"  turn {i}: {t['latency_ms']} ms")
+    print()
+    if stats["turns"]:
+        print(
+            f"  {stats['turns']} turns | "
+            f"median {stats['median_ms']} ms | "
+            f"mean {stats['mean_ms']} ms | "
+            f"min {stats['min_ms']} | max {stats['max_ms']}"
+        )
+    else:
+        print("  no complete turns found in log")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/acoustic-harness/tests/test_latency.py
+++ b/tools/acoustic-harness/tests/test_latency.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Tests for latency.py — measure true conversational latency from a session log.
+
+The in-app stopwatch measures user-FIRST-chunk -> AI-first-audio, which includes
+the whole user utterance + Gemini's VAD silence wait (#223). The industry
+standard, and what this analyzer computes, is user-LAST-speech -> AI-first-audio,
+using the device's single monotonic logcat clock (no cross-device sync).
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from latency import parse_timestamp, analyze_turns
+
+
+class TestParseTimestamp(unittest.TestCase):
+    def test_parses_logcat_time_to_ms(self):
+        # 06-15 17:50:44.816 -> ms within the day
+        ms = parse_timestamp("06-15 17:50:44.816")
+        self.assertEqual(ms, (((17 * 60) + 50) * 60 + 44) * 1000 + 816)
+
+    def test_two_timestamps_diff(self):
+        a = parse_timestamp("06-15 17:50:44.816")
+        b = parse_timestamp("06-15 17:50:46.300")
+        self.assertEqual(b - a, 1484)
+
+
+# A minimal but realistic session: user speaks (3 partials), stops at .891,
+# AI's first audio chunk lands at 2.034s later.
+SAMPLE_LOG = """\
+06-15 15:21:23.421 I/flutter ( 7245): [DYTTY] Call state: active
+06-15 15:21:27.203 I/flutter ( 7245): [DYTTY] User said:  Hey (final: false)
+06-15 15:21:27.475 I/flutter ( 7245): [DYTTY] User said:  there (final: false)
+06-15 15:21:27.891 I/flutter ( 7245): [DYTTY] User said:  how are you (final: false)
+06-15 15:21:29.925 I/flutter ( 7245): [DYTTY] Audio chunk received: 46080 bytes
+06-15 15:21:29.930 I/flutter ( 7245): [DYTTY] Audio chunk received: 1920 bytes
+06-15 15:21:30.100 I/flutter ( 7245): [DYTTY] AI said: Hi! (final: false)
+06-15 15:21:31.000 I/flutter ( 7245): [DYTTY] Turn complete
+"""
+
+
+class TestAnalyzeTurns(unittest.TestCase):
+    def _write(self, text):
+        f = tempfile.NamedTemporaryFile(
+            "w", suffix=".log", delete=False, encoding="utf-8"
+        )
+        f.write(text)
+        f.close()
+        self.addCleanup(os.unlink, f.name)
+        return f.name
+
+    def test_latency_is_last_user_speech_to_first_ai_audio(self):
+        turns = analyze_turns(self._write(SAMPLE_LOG))
+        self.assertEqual(len(turns), 1)
+        # 29.925 - 27.891 = 2034 ms (end-of-speech -> first AI audio)
+        self.assertEqual(turns[0]["latency_ms"], 2034)
+
+    def test_records_endpoints(self):
+        turns = analyze_turns(self._write(SAMPLE_LOG))
+        self.assertEqual(turns[0]["user_last_ms"], parse_timestamp("06-15 15:21:27.891"))
+        self.assertEqual(
+            turns[0]["ai_first_audio_ms"], parse_timestamp("06-15 15:21:29.925")
+        )
+
+    def test_naive_measurement_is_larger(self):
+        # The buggy in-app metric would measure from the FIRST user chunk
+        # (27.203), inflating it by the utterance duration.
+        turns = analyze_turns(self._write(SAMPLE_LOG))
+        naive = parse_timestamp("06-15 15:21:29.925") - parse_timestamp(
+            "06-15 15:21:27.203"
+        )
+        self.assertGreater(naive, turns[0]["latency_ms"])
+        self.assertEqual(naive - turns[0]["latency_ms"], 688)  # utterance span
+
+    def test_no_turns_when_no_audio(self):
+        log = (
+            "06-15 15:21:27.203 I/flutter ( 7245): [DYTTY] User said:  Hey (final: false)\n"
+        )
+        self.assertEqual(analyze_turns(self._write(log)), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/acoustic-harness/tests/test_latency.py
+++ b/tools/acoustic-harness/tests/test_latency.py
@@ -81,6 +81,31 @@ class TestAnalyzeTurns(unittest.TestCase):
         )
         self.assertEqual(analyze_turns(self._write(log)), [])
 
+    def test_breaks_down_into_processing_and_first_token_to_audio(self):
+        # end-of-speech 27.891 -> AI first token 29.000 = 1109ms processing;
+        # AI first token 29.000 -> first audio 29.925 = 925ms token->audio.
+        log = SAMPLE_LOG.replace(
+            "06-15 15:21:30.100 I/flutter ( 7245): [DYTTY] AI said: Hi! (final: false)\n",
+            "",
+        )
+        # Insert an AI-said BEFORE the audio chunk to mark first-token time.
+        log = log.replace(
+            "06-15 15:21:29.925 I/flutter ( 7245): [DYTTY] Audio chunk received: 46080 bytes",
+            "06-15 15:21:29.000 I/flutter ( 7245): [DYTTY] AI said: Hi (final: false)\n"
+            "06-15 15:21:29.925 I/flutter ( 7245): [DYTTY] Audio chunk received: 46080 bytes",
+        )
+        turns = analyze_turns(self._write(log))
+        self.assertEqual(turns[0]["latency_ms"], 2034)  # total unchanged
+        self.assertEqual(turns[0]["ai_first_token_ms"], parse_timestamp("06-15 15:21:29.000"))
+        self.assertEqual(turns[0]["processing_ms"], 1109)  # end-speech -> first token
+        self.assertEqual(turns[0]["token_to_audio_ms"], 925)  # first token -> audio
+
+    def test_breakdown_none_when_no_ai_token_before_audio(self):
+        # SAMPLE_LOG has no AI-said before the audio chunk.
+        turns = analyze_turns(self._write(SAMPLE_LOG))
+        self.assertIsNone(turns[0]["ai_first_token_ms"])
+        self.assertIsNone(turns[0]["processing_ms"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Complete daily-call-quality cluster from the owner's first working-call findings. Replaces the half-duplex mic-gate with the production-validated **open-mic + AEC + server-side-interrupt** architecture, fixes WebSocket recovery, corrects latency measurement, and fixes transcript truncation. Device-verified on Pixel 9a throughout.

Fixes #222
Fixes #12
Fixes #227
Fixes #223
Fixes #123

## What changed

- **#222 echo loop / silent AI** — open mic + platform AEC (`voiceCommunication` source) so the AI no longer hears its own speaker output and talks to itself. Diagnosed via the acoustic harness with known scripted input.
- **#12 barge-in** — read Gemini's server-side `LiveServerContent.interrupted`; flush playback + mark interrupted transcript on barge-in; suppress mic-send 400ms post-interrupt to kill "ghost input" (AI echo tail transcribed as phantom user text). Backed by a 4-agent research fan-out (academic FlexDuo, mainstream OpenAI/LiveKit/Deepgram/Nova, indie Reflection.app, Gemini-API).
- **#227 1008 WebSocket recovery** — null the session on receive-loop error so `sendAudio` stops flooding the dead socket; stop recorder on error state.
- **#223 latency** — built `tools/acoustic-harness/latency.py` (true end-of-speech → first-AI-audio on the device logcat clock). Real latency ~1.66s (was mis-measured as 3.5-4.5s); breakdown ~1260ms Gemini-processing + ~385ms token→audio, app ~0ms. Fixed the in-app stopwatch to anchor on recognized speech.
- **#123 transcript truncation** — Gemini streams transcript as incremental deltas; append them instead of replacing (bubbles were showing only the last fragment).

## Follow-ups filed
- **#228** — deterministic turn control via raw google-genai WebSocket (the only path to manual activityStart/End + tunable VAD silence-wait; would cut ~800ms of the ~1.66s latency). Tier 2.
- **#224** — multi-item utterances (deferred to its own PR).

## Test Plan
- [x] Full unit suite: **876 Flutter + 101 Python pass**, 0 analysis issues
- [x] Device-verified (Pixel 9a, real Firebase, acoustic harness, known input):
  - [x] Barge-in: AI stops promptly when spoken over; no echo loop; no ghost input
  - [x] Multi-turn conversation clean (no deadlock)
  - [x] Latency: in-app 1659ms ≈ analyzer 1660ms (measurement corrected)
  - [x] Transcript: harness 0.93 similarity (full sentence reconstructed)
- [ ] Gate 1 CI (runs on this PR)
- [ ] Gate 1.5 device CI (advisory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)